### PR TITLE
Segment timestamp type to date

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -71,7 +71,7 @@ export class SegmentAction extends Hub.Action {
     let fieldset: Hub.Field[] = []
     const errors: Error[] = []
 
-    let timestamp = Date.now()
+    let timestamp = new Date()
     const context = {
       app: {
         name: "looker/actions",
@@ -88,7 +88,7 @@ export class SegmentAction extends Hub.Action {
       },
       onRanAt: (iso8601string) => {
         if (iso8601string) {
-          timestamp = new Date(iso8601string).getTime()
+          timestamp = new Date(iso8601string)
         }
       },
       onRow: (row) => {

--- a/src/actions/segment/test_segment.ts
+++ b/src/actions/segment/test_segment.ts
@@ -13,7 +13,9 @@ function expectSegmentMatch(request: Hub.ActionRequest, match: any) {
       return {identify: segmentCallSpy, flush: (cb: () => void) => cb()}
      })
   const stubAnon = sinon.stub(action as any, "generateAnonymousId").callsFake(() => "stubanon")
-  const stubNow = sinon.stub(Date as any, "now").callsFake(() => "now")
+
+  const now = new Date()
+  const clock = sinon.useFakeTimers(now.getTime())
 
   const baseMatch = {
     traits: {},
@@ -23,7 +25,7 @@ function expectSegmentMatch(request: Hub.ActionRequest, match: any) {
         version: "dev",
       },
     },
-    timestamp: "now",
+    timestamp: now,
   }
   const merged = {...baseMatch, ...match}
 
@@ -31,7 +33,7 @@ function expectSegmentMatch(request: Hub.ActionRequest, match: any) {
     chai.expect(segmentCallSpy).to.have.been.calledWithExactly(merged)
     stubClient.restore()
     stubAnon.restore()
-    stubNow.restore()
+    clock.restore()
   })
 }
 
@@ -244,7 +246,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       return expectSegmentMatch(request, {
         anonymousId: "stubanon",
         userId: null,
-        timestamp: new Date("2017-07-28T02:25:19+00:00").getTime(),
+        timestamp: new Date("2017-07-28T02:25:19+00:00"),
         traits: {email: "funvalue"},
        })
     })

--- a/src/actions/segment/test_segment_group.ts
+++ b/src/actions/segment/test_segment_group.ts
@@ -13,7 +13,9 @@ function expectSegmentMatch(request: Hub.ActionRequest, match: any) {
       return { group: groupSpy, flush: (cb: () => void) => cb()}
      })
   const stubAnon = sinon.stub(action as any, "generateAnonymousId").callsFake(() => "stubanon")
-  const stubNow = sinon.stub(Date as any, "now").callsFake(() => "now")
+
+  const now = new Date()
+  const clock = sinon.useFakeTimers(now.getTime())
 
   const baseMatch = {
     traits: {},
@@ -23,7 +25,7 @@ function expectSegmentMatch(request: Hub.ActionRequest, match: any) {
         version: "dev",
       },
     },
-    timestamp: "now",
+    timestamp: now,
   }
   const merged = {...baseMatch, ...match}
 
@@ -31,7 +33,7 @@ function expectSegmentMatch(request: Hub.ActionRequest, match: any) {
     chai.expect(groupSpy).to.have.been.calledWithExactly(merged)
     stubClient.restore()
     stubAnon.restore()
-    stubNow.restore()
+    clock.restore()
   })
 }
 

--- a/src/actions/segment/test_segment_track.ts
+++ b/src/actions/segment/test_segment_track.ts
@@ -17,7 +17,9 @@ describe(`${action.constructor.name} unit tests`, () => {
           return {track: segmentCallSpy, flush: (cb: () => void) => cb()}
         })
       const stubAnon = sinon.stub(action as any, "generateAnonymousId").callsFake(() => "stubanon")
-      const stubNow = sinon.stub(Date as any, "now").callsFake(() => "now")
+
+      const now = new Date()
+      const clock = sinon.useFakeTimers(now.getTime())
 
       const request = new Hub.ActionRequest()
       request.formParams = {
@@ -44,11 +46,11 @@ describe(`${action.constructor.name} unit tests`, () => {
               version: "dev",
             },
           },
-          timestamp: "now",
+          timestamp: now,
         })
         stubClient.restore()
         stubAnon.restore()
-        stubNow.restore()
+        clock.restore()
       })
     })
   })


### PR DESCRIPTION
This should fix segment. The oboe error handling was catching the error and removing the stack trace for an assertion error that timestamp was a Date type and not a numeric timestamp.