### PR TITLE
Import Slack so that type definitions come through

### DIFF
--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -1,6 +1,6 @@
 import * as Hub from "../../hub"
 
-const WebClient = require("@slack/client").WebClient
+import { WebClient } from "@slack/client"
 
 interface Channel {
   id: string,
@@ -94,8 +94,8 @@ export class SlackAttachmentAction extends Hub.Action {
     return new Promise<Channel[]>((resolve, reject) => {
       const slack = this.slackClientFromRequest(request)
       slack.channels.list({
-        exclude_archived: 1,
-        exclude_members: 1,
+        exclude_archived: true,
+        exclude_members: true,
       }, (err: any, response: any) => {
         if (err || !response.ok) {
           reject(err)


### PR DESCRIPTION
this masked the bug from https://github.com/looker/actions/pull/154