### PR TITLE
Don't let initial_comment be undefined for Slack

### DIFF
--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -39,7 +39,7 @@ export class SlackAttachmentAction extends Hub.Action {
       filename: fileName,
       channels: request.formParams.channel,
       filetype: request.attachment.fileExtension,
-      initial_comment: request.formParams.initial_comment,
+      initial_comment: request.formParams.initial_comment || "",
     }
 
     let response


### PR DESCRIPTION
The Slack SDK throws an error if `initial_comment` is set to `undefined`, but is fine with an empty string.