### PR TITLE
try to capture better error info for segment

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -130,7 +130,7 @@ export class SegmentAction extends Hub.Action {
     if (errors) {
       return new Hub.ActionResponse({
         success: false,
-        message: errors.map((e) => e.message).join(", "),
+        message: errors.map((e) => e.message || e).join(", "),
       })
     } else {
       return new Hub.ActionResponse({ success: true })


### PR DESCRIPTION
`e` could be a string here potentially which would cause a blank error message