### PR TITLE
Disable segment streaming temporarily

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -46,7 +46,7 @@ export class SegmentAction extends Hub.Action {
   ]
   minimumSupportedLookerVersion = "4.20.0"
   supportedActionTypes = [Hub.ActionType.Query]
-  usesStreaming = true
+  usesStreaming = false
   supportedFormats = [Hub.ActionFormat.JsonDetail]
   supportedFormattings = [Hub.ActionFormatting.Unformatted]
   supportedVisualizationFormattings = [Hub.ActionVisualizationFormatting.Noapply]
@@ -57,6 +57,11 @@ export class SegmentAction extends Hub.Action {
   }
 
   protected async executeSegment(request: Hub.ActionRequest, segmentCall: SegmentCalls) {
+
+    if (!request.attachment) {
+      throw "The segment action requires an attachment."
+    }
+
     const segmentClient = this.segmentClientFromRequest(request)
 
     let hiddenFields: string[] = []

--- a/src/actions/segment/test_segment.ts
+++ b/src/actions/segment/test_segment.ts
@@ -259,7 +259,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       }
       return chai.expect(action.validateAndExecute(request)).to.eventually
         .be.rejectedWith(
-          "A streaming action was sent incompatible data. The action must have a download url or an attachment.")
+          "The segment action requires an attachment.")
     })
 
     it("errors if the query response has no fields", (done) => {


### PR DESCRIPTION
We are encountering memory issues with our streaming JSON parser (Oboe) and so disable Segment while we determine the best course of action.