### PR TITLE
Fix the Hub.Field type to be partial

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -149,7 +149,7 @@ export class SegmentAction extends Hub.Action {
 
   protected taggedFields(fields: Hub.Field[], tags: string[]) {
     return fields.filter((f) =>
-      f.tags.length > 0 && f.tags.some((t: string) => tags.indexOf(t) !== -1),
+      f.tags && f.tags.length > 0 && f.tags.some((t: string) => tags.indexOf(t) !== -1),
     )
   }
 

--- a/src/actions/segment/test_segment.ts
+++ b/src/actions/segment/test_segment.ts
@@ -188,8 +188,8 @@ describe(`${action.constructor.name} unit tests`, () => {
         fields: {
           dimensions: [
             {name: "coolfield", tags: ["email"]},
-            {name: "hiddenfield", tags: []},
-            {name: "nonhiddenfield", tags: []},
+            {name: "hiddenfield"},
+            {name: "nonhiddenfield"},
           ]},
         data: [{
           coolfield: {value: "funvalue"},

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -5,9 +5,15 @@ export * from "./action"
 export * from "./sources"
 export * from "./utils"
 
-import { LookmlModelExploreField as Field } from "../api_types/lookml_model_explore_field"
+import { LookmlModelExploreField as FieldBase } from "../api_types/lookml_model_explore_field"
 import { LookmlModelExploreFieldset as ExploreFieldset } from "../api_types/lookml_model_explore_fieldset"
 import * as JsonDetail from "./json_detail"
+
+// LookmlModelExploreField is not the same as what Looker will actually send
+// The fields are right, but some are omitted in json_detail.
+interface Field extends Partial<FieldBase> {
+  name: string
+}
 
 interface Fieldset extends ExploreFieldset {
   table_calculations: Field[] | null


### PR DESCRIPTION
LookmlModelExploreField is not the same as what Looker will actually send. The fields are right, but some are omitted in json_detail.

I introduced this in https://github.com/looker/actions/pull/172 – it's tricky when applying types to JSON because you can end up lying to yourself.

closes https://github.com/looker/helltool/issues/38148