### PR TITLE
Improve error handling for form errors

### DIFF
--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -85,7 +85,7 @@ export class SlackAttachmentAction extends Hub.Action {
       }]
 
     } catch (e) {
-      form.error = e
+      form.error = this.prettySlackError(e)
     }
 
     return form
@@ -130,6 +130,14 @@ export class SlackAttachmentAction extends Hub.Action {
         }
       })
     })
+  }
+
+  private prettySlackError(e: any) {
+    if (e.message === "An API error occurred: invalid_auth") {
+      return "Your Slack authentication credentials are not valid."
+    } else {
+      return e
+    }
   }
 
   private slackClientFromRequest(request: Hub.ActionRequest) {

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -24,6 +24,7 @@ export class SlackAttachmentAction extends Hub.Action {
   }]
 
   async execute(request: Hub.ActionRequest) {
+
     if (!request.attachment || !request.attachment.dataBuffer) {
       throw "Couldn't get data from attachment."
     }
@@ -62,24 +63,30 @@ export class SlackAttachmentAction extends Hub.Action {
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
-    const channels = await this.usableChannels(request)
 
-    form.fields = [{
-      description: "Name of the Slack channel you would like to post to.",
-      label: "Share In",
-      name: "channel",
-      options: channels.map((channel) => ({name: channel.id, label: channel.label})),
-      required: true,
-      type: "select",
-    }, {
-      label: "Comment",
-      type: "string",
-      name: "initial_comment",
-    }, {
-      label: "Filename",
-      name: "filename",
-      type: "string",
-    }]
+    try {
+      const channels = await this.usableChannels(request)
+
+      form.fields = [{
+        description: "Name of the Slack channel you would like to post to.",
+        label: "Share In",
+        name: "channel",
+        options: channels.map((channel) => ({ name: channel.id, label: channel.label })),
+        required: true,
+        type: "select",
+      }, {
+        label: "Comment",
+        type: "string",
+        name: "initial_comment",
+      }, {
+        label: "Filename",
+        name: "filename",
+        type: "string",
+      }]
+
+    } catch (e) {
+      form.error = e
+    }
 
     return form
   }

--- a/src/hub/action_form.ts
+++ b/src/hub/action_form.ts
@@ -1,6 +1,10 @@
 export class ActionForm {
   fields: ActionFormField[] = []
+  error?: Error | string
   asJson(): any {
+    if (this.error) {
+      return {success: false, message: typeof this.error === "string" ? this.error : this.error.message}
+    }
     return this.fields
   }
 }

--- a/src/hub/action_form.ts
+++ b/src/hub/action_form.ts
@@ -3,7 +3,7 @@ export class ActionForm {
   error?: Error | string
   asJson(): any {
     if (this.error) {
-      return {success: false, message: typeof this.error === "string" ? this.error : this.error.message}
+      return {error: typeof this.error === "string" ? this.error : this.error.message}
     }
     return this.fields
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -126,8 +126,11 @@ export default class Server implements Hub.RouteBuilder {
       const request = Hub.ActionRequest.fromRequest(req)
       const action = await Hub.findAction(req.params.actionId, { lookerVersion: request.lookerVersion })
       if (action.hasForm) {
-         const form = await action.validateAndFetchForm(request)
-         res.json(form.asJson())
+        const form = await action.validateAndFetchForm(request)
+        if (form.error) {
+          res.status(400)
+        }
+        res.json(form.asJson())
       } else {
         throw "No form defined for action."
       }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -127,9 +127,6 @@ export default class Server implements Hub.RouteBuilder {
       const action = await Hub.findAction(req.params.actionId, { lookerVersion: request.lookerVersion })
       if (action.hasForm) {
         const form = await action.validateAndFetchForm(request)
-        if (form.error) {
-          res.status(400)
-        }
         res.json(form.asJson())
       } else {
         throw "No form defined for action."


### PR DESCRIPTION
In general, passes the error messages back to Looker in a way it can understand them.

Specifically also catches then pretties up the error messages for a common Slack error message.