### PR TITLE
Make Dockerfile more cache-friendly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM node:10.8.0
+RUN npm install -g -s --no-progress yarn@1.9.4
+
 RUN mkdir -p /code
 WORKDIR /code
-ADD . /code
 
-RUN npm install -g -s --no-progress yarn
-RUN yarn install --production
+COPY package.json yarn.lock tsconfig.json tsconfig.npm.json /code/
+RUN yarn install --production && yarn cache clean
+
+COPY . /code
 
 CMD ["yarn","start"]
 
-EXPOSE 80
+EXPOSE 8080


### PR DESCRIPTION
The order that operations are listed in the Dockerfile were not optimal with respect to maximizing the use of the build cache. It is best to copy the package.json (and related files) out into their own instruction and then install packages.

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache