### PR TITLE
Child Process Error Handling Improvements

### DIFF
--- a/src/hub/action.ts
+++ b/src/hub/action.ts
@@ -2,6 +2,7 @@ import * as fs from "fs"
 import * as path from "path"
 import {ExecuteProcessQueue} from "../xpc/execute_process_queue"
 
+import * as winston from "winston"
 import {
   ActionDownloadSettings,
   ActionForm,
@@ -113,6 +114,7 @@ export abstract class Action {
           Object.assign(actionResponse, response)
           resolve(actionResponse)
         }).catch((err) => {
+          winston.error(JSON.stringify(err))
           reject(err)
         })
       })

--- a/src/xpc/execute_process.ts
+++ b/src/xpc/execute_process.ts
@@ -9,7 +9,7 @@ async function execute(jsonPayload: any) {
 }
 
 process.on("message", (req) => {
-    const response = execute(req)
-    response.then((val) => { process.send!(val)})
+    execute(req)
+        .then((val) => { process.send!(val)})
         .catch((err) => { process.send!({success: false, message: JSON.stringify(err)})})
 })


### PR DESCRIPTION
Adding an extra log message and redoing .catch to be immediately attached for execute_process to capture unhandled exceptions (small race condition)

