### PR TITLE
Include xpc in NPM tsconfig

### DIFF
--- a/tsconfig.npm.json
+++ b/tsconfig.npm.json
@@ -3,6 +3,7 @@
   "include": [
     "src/api_types/**/*.ts",
     "src/hub/**/*.ts",
-    "src/server/**/*.ts"
+    "src/server/**/*.ts",
+    "src/xpc/**/**.ts"
   ]
 }


### PR DESCRIPTION
Ensures that users like myself who run private hubs can still pull from GitHub during development.

**Problem**
```
$ yarn start
yarn run v1.9.4
$ ./node_modules/.bin/ts-node ./src/index.ts
Error: Cannot find module '../xpc/execute_process_queue'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\<...>\node_modules\looker-action-hub\lib\server\server.js:19
:29)
```

**Solution**
Ensure XPC stuff gets compiled during postinstall.