### PR TITLE
Execute and form requests attempt to keep the connection alive

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -116,29 +116,23 @@ export default class Server implements Hub.RouteBuilder {
       res.json(action.asJson(this))
     })
 
-    this.route("/actions/:actionId/execute", async (req, res) => {
+    this.route("/actions/:actionId/execute", this.jsonKeepAlive(async (req, complete) => {
       const request = Hub.ActionRequest.fromRequest(req)
       const action = await Hub.findAction(req.params.actionId, { lookerVersion: request.lookerVersion })
       const actionResponse = await action.validateAndExecute(request, expensiveJobQueue)
-      // Some versions of Looker do not look at the "success" value in the response
-      // if the action returns a 200 status code, even though the Action API specs otherwise.
-      // So we force a non-200 status code as a workaround.
-      if (!actionResponse.success) {
-          res.status(400)
-      }
-      res.json(actionResponse.asJson())
-    })
+      complete(actionResponse.asJson())
+    }))
 
-    this.route("/actions/:actionId/form", async (req, res) => {
+    this.route("/actions/:actionId/form", this.jsonKeepAlive(async (req, complete) => {
       const request = Hub.ActionRequest.fromRequest(req)
       const action = await Hub.findAction(req.params.actionId, { lookerVersion: request.lookerVersion })
       if (action.hasForm) {
         const form = await action.validateAndFetchForm(request)
-        res.json(form.asJson())
+        complete(form.asJson())
       } else {
         throw "No form defined for action."
       }
-    })
+    }))
 
     // To provide a health or version check endpoint you should place a status.json file
     // into the project root, which will get served by this endpoint (or 404 otherwise).
@@ -154,6 +148,34 @@ export default class Server implements Hub.RouteBuilder {
 
   formUrl(action: Hub.Action) {
     return this.absUrl(`/actions/${encodeURIComponent(action.name)}/form`)
+  }
+
+  /**
+   * For JSON responses that take a long time without sending any data,
+   * we periodically send a newline character to prevent the connection from being
+   * dropped by proxies or other services (like the AWS NAT Gateway).
+   */
+  private jsonKeepAlive(fn: (req: express.Request, complete: (data: any) => void) => Promise<void>):
+  (req: express.Request, res: express.Response) => Promise<void> {
+    const interval = process.env.ACTION_HUB_JSON_KEEPALIVE_SEC ?
+        parseInt(process.env.ACTION_HUB_JSON_KEEPALIVE_SEC, 10)
+      :
+        30
+    return async (req, res) => {
+      res.status(200)
+      res.setHeader("Content-Type", "application/json")
+      const timer = setInterval(() => {
+        res.write("\n")
+      }, interval * 1000)
+      try {
+        await fn(req, (data) => {
+          res.write(JSON.stringify(data))
+          res.end()
+        })
+      } finally {
+        clearInterval(timer)
+      }
+    }
   }
 
   private route(urlPath: string, fn: (req: express.Request, res: express.Response) => Promise<void>): void {


### PR DESCRIPTION
We've determined AWS's [NAT Gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) is timing out action requests longer that 5 minutes in certain deployment setups. This attempts to prevent that by regularly sending newlines in the HTTP response body (since they don't affect JSON parsing).

This removes a workaround we had in place for older versions of Looker where the execute request would return 400 in the event of an error. Older versions of Looker (<5.14.25, 5.16.0 – 5.16.13, 5.18.0, 5.18.1) couldn't handle a 200 with a failure message – they just treated those as successes. Unfortunately due to the nature of this keep-alive we have to send the HTTP status code immediately before we know whether the action succeeded, meaning older Looker instances will not properly see failure messages.