### PR TITLE
Adding json-detail-lite-stream in the case of Segment and Looker v6.2 or greater

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -2,8 +2,11 @@ import * as util from "util"
 import * as uuid from "uuid"
 import * as winston from "winston"
 
+import * as semver from "semver"
 import * as Hub from "../../hub"
-import { SegmentActionError } from "./segment_error"
+import {ActionDownloadSettings} from "../../hub"
+import {RouteBuilder} from "../../hub"
+import {SegmentActionError} from "./segment_error"
 
 const segment: any = require("analytics-node")
 
@@ -54,6 +57,34 @@ export class SegmentAction extends Hub.Action {
   supportedVisualizationFormattings = [Hub.ActionVisualizationFormatting.Noapply]
   requiredFields = [{ any_tag: this.allowedTags }]
   executeInOwnProcess = true
+
+  asJson(router: RouteBuilder, request: Hub.ActionRequest): any {
+    let formats = this.supportedFormats
+    if (request.lookerVersion && semver.gte(request.lookerVersion, "6.2.0")) {
+      formats = [Hub.ActionFormat.JsonDetailLiteStream]
+    }
+    return {
+      description: this.description,
+      form_url: this.form ? router.formUrl(this) : null,
+      label: this.label,
+      name: this.name,
+      params: this.params,
+      required_fields: this.requiredFields,
+      supported_action_types: this.supportedActionTypes,
+      supported_formats: formats,
+      supported_formattings: this.supportedFormattings,
+      supported_visualization_formattings: this.supportedVisualizationFormattings,
+      supported_download_settings: (
+        this.usesStreaming
+          ?
+          [ActionDownloadSettings.Url]
+          :
+          [ActionDownloadSettings.Push]
+      ),
+      icon_data_uri: this.getImageDataUri(),
+      url: router.actionUrl(this),
+    }
+  }
 
   async execute(request: Hub.ActionRequest) {
     return this.executeSegment(request, SegmentCalls.Identify)

--- a/src/api_types/integration.ts
+++ b/src/api_types/integration.ts
@@ -20,6 +20,7 @@ export enum IntegrationSupportedFormats {
   InlineJson = 'inline_json',
   Json = 'json',
   JsonDetail = 'json_detail',
+  JsonDetailLiteStream = 'json_detail_lite_stream',
   Xlsx = 'xlsx',
   Html = 'html',
   WysiwygPdf = 'wysiwyg_pdf',

--- a/src/hub/action.ts
+++ b/src/hub/action.ts
@@ -42,6 +42,10 @@ export interface RouteBuilder {
 
 export abstract class Action {
 
+  get hasForm() {
+    return !!this.form
+  }
+
   abstract name: string
   abstract label: string
   abstract description: string
@@ -60,7 +64,7 @@ export abstract class Action {
 
   abstract params: ActionParameter[]
 
-  asJson(router: RouteBuilder) {
+  asJson(router: RouteBuilder, _request: ActionRequest) {
     return {
       description: this.description,
       form_url: this.form ? router.formUrl(this) : null,
@@ -138,8 +142,15 @@ export abstract class Action {
     return this.form!(request)
   }
 
-  get hasForm() {
-    return !!this.form
+  getImageDataUri() {
+    if (!this.iconName) {
+      return null
+    }
+    const iconPath = path.resolve(__dirname, "..", "actions", this.iconName)
+    if (fs.existsSync(iconPath)) {
+      return new datauri(iconPath).content
+    }
+    return null
   }
 
   private throwForMissingRequiredParameters(request: ActionRequest) {
@@ -153,17 +164,6 @@ export abstract class Action {
         }
       }
     }
-  }
-
-  private getImageDataUri() {
-    if (!this.iconName) {
-      return null
-    }
-    const iconPath = path.resolve(__dirname, "..", "actions", this.iconName)
-    if (fs.existsSync(iconPath)) {
-      return new datauri(iconPath).content
-    }
-    return null
   }
 
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -113,7 +113,7 @@ export default class Server implements Hub.RouteBuilder {
     this.route("/actions/:actionId", async (req, res) => {
       const request = Hub.ActionRequest.fromRequest(req)
       const action = await Hub.findAction(req.params.actionId, { lookerVersion: request.lookerVersion })
-      res.json(action.asJson(this))
+      res.json(action.asJson(this, request))
     })
 
     this.route("/actions/:actionId/execute", this.jsonKeepAlive(async (req, complete) => {


### PR DESCRIPTION
This format is not 100% the same as json_detail  however it provides what Segment needs in order to stream in an unlimited fashion.