### PR TITLE
Separate Server.run() into configure and run functions

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,6 +21,11 @@ const expensiveJobQueue = new ExecuteProcessQueue.ExecuteProcessQueue()
 export default class Server implements Hub.RouteBuilder {
 
   static run() {
+    const { port, timeout } = Server.configure()
+    Server.listen(port, timeout)
+  }
+
+  static configure() {
     dotenv.config()
 
     if (useRaven()) {
@@ -65,7 +70,10 @@ export default class Server implements Hub.RouteBuilder {
     // Load balancers in front of the app may still timeout
     const timeout = process.env.ACTION_HUB_SOCKET_TIMEOUT ? parseInt(process.env.ACTION_HUB_SOCKET_TIMEOUT, 10) : 0
 
-    Server.listen(port, timeout)
+    return {
+      port,
+      timeout,
+    }
   }
 
   static listen(port: number, timeout: number) {


### PR DESCRIPTION
`Server.run()` is currently responsible for both configuration and actually running the server. This PR separates those responsibilities.

`Server.configure()` does its setup work and returns a configuration object. `Server.run()` calls `configure()` to obtain a configuration, and then launches the server. This supports use cases where a user wants to create a Server object themselves, e.g. to have access to the Express app. This way, the user can still leverage the validation and setup done in the existing `run()` function without the server being automatically launched.

I'm not totally sold on the ergonomics and future maintainability of this approach, but it's a super simple change and doesn't alter any existing usage patterns. `configure()` still has multiple responsibilities (validate environment variables, configure Raven, configure winston, determine port/timeout), but could sprout independent functions for those later.

Ideally, there would be some sort of `IServerConfiguration` interface which `configure()` would return and `listen()` would consume, but I wouldn't want to change the signature of `listen()` without understanding how people might be using it aside from through `run()`.

If you have thoughts I'll happily make changes.

Old:
```javascript
Server.run();
```

New:
```javascript
Server.run();

// or

const { port, timeout } = Server.configure();
const server = new Server();
createSomeMiddlewareStack(port).use(server.app);
```