### PR TITLE
Slight refactor of Azure - Looking at container errors

### DIFF
--- a/src/actions/azure/azure_storage.ts
+++ b/src/actions/azure/azure_storage.ts
@@ -64,27 +64,30 @@ export class AzureStorageAction extends Hub.Action {
     // https://github.com/Azure/azure-storage-node/issues/352
     const form = new Hub.ActionForm()
     const blogService: any = this.azureClientFromRequest(request)
-    blogService.listContainersSegmented(null, (err: any, res: any) => {
-      if (err) {
-        form.error = err
-      } else {
-        form.fields = [{
-          label: "Container",
-          name: "container",
-          required: true,
-          options: res.entries.map((c: any) => {
+    return new Promise<Hub.ActionForm>((resolve, _reject) => {
+      blogService.listContainersSegmented(null, (err: any, res: any) => {
+        if (err) {
+          form.error = err
+          resolve(form)
+        } else {
+          form.fields = [{
+            label: "Container",
+            name: "container",
+            required: true,
+            options: res.entries.map((c: any) => {
               return {name: c.id, label: c.name}
             }),
-          type: "select",
-          default: res.entries[0].id,
-        }, {
-          label: "Filename",
-          name: "filename",
-          type: "string",
-        }]
-      }
+            type: "select",
+            default: res.entries[0].id,
+          }, {
+            label: "Filename",
+            name: "filename",
+            type: "string",
+          }]
+          resolve(form)
+        }
+      })
     })
-    return form
   }
 
   private azureClientFromRequest(request: Hub.ActionRequest) {

--- a/src/actions/azure/azure_storage.ts
+++ b/src/actions/azure/azure_storage.ts
@@ -75,10 +75,10 @@ export class AzureStorageAction extends Hub.Action {
             name: "container",
             required: true,
             options: res.entries.map((c: any) => {
-              return {name: c.id, label: c.name}
+              return {name: c.name, label: c.name}
             }),
             type: "select",
-            default: res.entries[0].id,
+            default: res.entries[0].name,
           }, {
             label: "Filename",
             name: "filename",

--- a/src/actions/azure/azure_storage.ts
+++ b/src/actions/azure/azure_storage.ts
@@ -27,70 +27,64 @@ export class AzureStorageAction extends Hub.Action {
   ]
 
   async execute(request: Hub.ActionRequest) {
+    if (!request.attachment || !request.attachment.dataBuffer) {
+      throw "Couldn't get data from attachment"
+    }
+
+    if (!request.formParams.container) {
+      throw "Need Azure container."
+    }
+
+    const blobService = this.azureClientFromRequest(request)
+    const fileName = request.formParams.filename || request.suggestedFilename()
+    const container = request.formParams.container
+    const data = request.attachment.dataBuffer
+
+    if (!fileName) {
+      return new Hub.ActionResponse({ success: false, message: "Cannot determine a filename." })
+    }
+
     return new Promise<Hub.ActionResponse>((resolve, reject) => {
-
-      if (!request.attachment || !request.attachment.dataBuffer) {
-        reject("Couldn't get data from attachment")
-        return
-      }
-
-      if (!request.formParams.container) {
-        reject("Need Azure container.")
-        return
-      }
-
-      const blobService = this.azureClientFromRequest(request)
-      const fileName = request.formParams.filename || request.suggestedFilename()
-
-      if (!fileName) {
-        reject("Cannot determine a filename.")
-        return
-      }
-
       blobService.createBlockBlobFromText(
-        request.formParams.container,
+        container,
         fileName,
-        request.attachment.dataBuffer,
+        data,
         (e?: Error) => {
           if (e) {
-            resolve(new Hub.ActionResponse({ success: false, message: e.message }))
+            reject(new Hub.ActionResponse({success: false, message: e.message}))
           } else {
-            resolve(new Hub.ActionResponse({ success: true }))
+            resolve(new Hub.ActionResponse({success: true}))
           }
         })
     })
   }
 
   async form(request: Hub.ActionRequest) {
-    const promise = new Promise<Hub.ActionForm>((resolve, reject) => {
-      // error in type definition for listContainersSegmented currentToken?
-      // https://github.com/Azure/azure-storage-node/issues/352
-      const blogService: any = this.azureClientFromRequest(request)
-      blogService.listContainersSegmented(null, (err: any, res: any) => {
-        if (err) {
-          reject(err)
-        } else {
-          const form = new Hub.ActionForm()
-          form.fields = [{
-            label: "Container",
-            name: "container",
-            required: true,
-            options: res.entries.map((c: any) => {
-                return {name: c.id, label: c.name}
-              }),
-            type: "select",
-            default: res.entries[0].id,
-          }, {
-            label: "Filename",
-            name: "filename",
-            type: "string",
-          }]
-
-          resolve(form)
-        }
-      })
+    // error in type definition for listContainersSegmented currentToken?
+    // https://github.com/Azure/azure-storage-node/issues/352
+    const form = new Hub.ActionForm()
+    const blogService: any = this.azureClientFromRequest(request)
+    blogService.listContainersSegmented(null, (err: any, res: any) => {
+      if (err) {
+        form.error = err
+      } else {
+        form.fields = [{
+          label: "Container",
+          name: "container",
+          required: true,
+          options: res.entries.map((c: any) => {
+              return {name: c.id, label: c.name}
+            }),
+          type: "select",
+          default: res.entries[0].id,
+        }, {
+          label: "Filename",
+          name: "filename",
+          type: "string",
+        }]
+      }
     })
-    return promise
+    return form
   }
 
   private azureClientFromRequest(request: Hub.ActionRequest) {

--- a/src/actions/azure/test_azure_storage.ts
+++ b/src/actions/azure/test_azure_storage.ts
@@ -96,8 +96,8 @@ describe(`${action.constructor.name} unit tests`, () => {
             chai.expect(filter).to.equal(null)
             const containers = {
               entries: [
-                {id: "1", name: "A"},
-                {id: "2", name: "B"},
+                {id: "A", name: "A"},
+                {id: "B", name: "B"},
               ],
             }
             cb(null, containers)
@@ -116,11 +116,11 @@ describe(`${action.constructor.name} unit tests`, () => {
           name: "container",
           required: true,
           options: [
-            {name: "1", label: "A"},
-            {name: "2", label: "B"},
+            {name: "A", label: "A"},
+            {name: "B", label: "B"},
           ],
           type: "select",
-          default: "1",
+          default: "A",
         }, {
           label: "Filename",
           name: "filename",


### PR DESCRIPTION
The Container object returned from the Azure ` listContainersSegmented ` call actually doesn't have an `id` component. The correct way to identify a container is its name