### PR TITLE
Fabio looker/marketo endpoint enhancements

### DIFF
--- a/src/actions/marketo/README.md
+++ b/src/actions/marketo/README.md
@@ -1,7 +1,6 @@
 # Marketo
-## Send leads from an Explore into a campaign in Marketo
 
-This action allows you to push rows from a query in Looker to a campaign in Marketo. 
+This action takes a query result and uses it to update a set of leads in Marketo, and to edit the leads' memberships in campaigns and lists. 
 
 ## SETUP
 
@@ -20,17 +19,18 @@ This action allows you to push rows from a query in Looker to a campaign in Mark
 
 When you use the Marketo Action in Looker, Looker does two steps in sequence:
 
-1. It upserts records in Marketo with any new information. (That is, if a record already exists, it updates it, and if the record does not exist, it creates it.)
-2. It puts the upserted records in the campaign you specify.
+1. It upserts lead records in Marketo with any new information. (That is, if a record already exists, it updates it, and if the record does not exist, it creates it.)
+2. It optionally adds or removes the lead in the campaign or list you specify
 
 To use this Action, run a query in Looker with all the fields that you want to send to Marketo. This query must contain a lookup field that identifies each record (most commonly email).
     
 1. Run a query to generate the rows you want to push to Marketo.
 2. Click the gear icon, choose Send..., then choose Marketo as the destination.
-3. Enter the id of the campaign you'd like to send the leads to.
-4. If you want to use a lookup field other than email, change that field to the REST API name of the lookup field. Otherwise leave it as `email`.
-5. If you want to send all rows (and ignore the limit on the query), select "All Results" under Advanced Options.
-6. Hit send and let the magic happen.
+3. If you want to use a lookup field other than email, change that field to the REST API name of the lookup field. Otherwise leave it as `email`.
+4. Choose whether you want to just update leads, or whether you want to add/remove them to a campaign or list.
+5. If applicable, enter the id of the campaign or list for which you'd like to add/remove the leads.
+6. If you want to send all rows (and ignore the limit on the query), select "All Results" under Advanced Options.
+7. Hit send and let the magic happen.
 
 ## THINGS TO KNOW
 

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -70,13 +70,13 @@ export class MarketoAction extends Hub.Action {
       name: "addListIds",
       type: "string",
       description: "List IDs to add the leads to, if any, comma-separated",
-      required: true,
+      required: false,
     }, {
       label: "Remove from List IDs (optional)",
       name: "removeListIds",
       type: "string",
       description: "List IDs to remove the leads from, if any, comma-separated",
-      required: true,
+      required: false,
     }]
     return form
   }

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -66,18 +66,18 @@ export class MarketoAction extends Hub.Action {
       type: "select",
       options: [
         {
-          name:"none",
-          label:"None - Update lead only",
+          name: "none",
+          label: "None - Update lead only",
         }, {
-          name:"addCampaign",
-          label:"Update lead and add to below Campaign ID",
+          name: "addCampaign",
+          label: "Update lead and add to below Campaign ID",
         }, {
-          name:"addList",
-          label:"Update lead and add to below List ID",
+          name: "addList",
+          label: "Update lead and add to below List ID",
         }, {
-          name:"removeList",
-          label:"Update lead and remove from below List ID",
-        }
+          name: "removeList",
+          label: "Update lead and remove from below List ID",
+        },
       ],
       description: "Additional action to take",
       default: "none",

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -70,7 +70,7 @@ export class MarketoAction extends Hub.Action {
           label:"None - Update lead only",
         }, {
           name:"addCampaign",
-          label:"Update lead and add to below Campain ID",
+          label:"Update lead and add to below Campaign ID",
         }, {
           name:"addList",
           label:"Update lead and add to below List ID",

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -46,6 +46,7 @@ export class MarketoAction extends Hub.Action {
   async execute(request: Hub.ActionRequest) {
     // create a stateful object to manage the transaction
     const transaction = new MarketoTransaction()
+
     // return the response from the transaction object
     return transaction.handleRequest(request)
   }

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -57,26 +57,36 @@ export class MarketoAction extends Hub.Action {
       label: "Lead Lookup Field",
       name: "lookupField",
       type: "string",
-      description: "Marketo field to use for lookup",
+      description: "Marketo field to use when looking up leads to update",
       default: "email",
       required: true,
     }, {
-      label: "Add to Campaign IDs (optional)",
-      name: "campaignIds",
-      type: "string",
-      description: "Campaign IDs to add the leads to, if any, comma-separated",
-      required: false,
+      label: "Additional Action",
+      name: "subaction",
+      type: "select",
+      options: [
+        {
+          name:"none",
+          label:"None - Update lead only",
+        }, {
+          name:"addCampaign",
+          label:"Update lead and add to below Campain ID",
+        }, {
+          name:"addList",
+          label:"Update lead and add to below List ID",
+        }, {
+          name:"removeList",
+          label:"Update lead and remove from below List ID",
+        }
+      ],
+      description: "Additional action to take",
+      default: "none",
+      required: true,
     }, {
-      label: "Add to List IDs (optional)",
-      name: "addListIds",
+      label: "Campaign/List ID for Additional Action",
+      name: "subactionIds",
       type: "string",
-      description: "List IDs to add the leads to, if any, comma-separated",
-      required: false,
-    }, {
-      label: "Remove from List IDs (optional)",
-      name: "removeListIds",
-      type: "string",
-      description: "List IDs to remove the leads from, if any, comma-separated",
+      description: "Either a Campaign ID or a List ID, depending on above selection",
       required: false,
     }]
     return form

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -46,7 +46,6 @@ export class MarketoAction extends Hub.Action {
   async execute(request: Hub.ActionRequest) {
     // create a stateful object to manage the transaction
     const transaction = new MarketoTransaction()
-    console.log(JSON.stringify(request,undefined,4))
     // return the response from the transaction object
     return transaction.handleRequest(request)
   }
@@ -61,22 +60,22 @@ export class MarketoAction extends Hub.Action {
       default: "email",
       required: true,
     }, {
-      label: "Add to Campaign ID (optional)",
-      name: "campaignId",
+      label: "Add to Campaign IDs (optional)",
+      name: "campaignIds",
       type: "string",
-      description: "Campaign ID to add the leads to, if any",
+      description: "Campaign IDs to add the leads to, if any, comma-separated",
       required: false,
     }, {
-      label: "Add to Static List ID (optional)",
-      name: "addStaticList",
+      label: "Add to List IDs (optional)",
+      name: "addListIds",
       type: "string",
-      description: "Static List ID to add the leads to, if any",
+      description: "List IDs to add the leads to, if any, comma-separated",
       required: true,
     }, {
-      label: "Remove from Static List ID (optional)",
-      name: "removeStaticList",
+      label: "Remove from List IDs (optional)",
+      name: "removeListIds",
       type: "string",
-      description: "Static List ID to remove the leads from, if any.",
+      description: "List IDs to remove the leads from, if any, comma-separated",
       required: true,
     }]
     return form

--- a/src/actions/marketo/marketo.ts
+++ b/src/actions/marketo/marketo.ts
@@ -6,7 +6,7 @@ export class MarketoAction extends Hub.Action {
   name = "marketo"
   label = "Marketo"
   iconName = "marketo/marketo.svg"
-  description = "Update leads and add to Marketo campaign."
+  description = "Update Marketo leads and their campaign/list membership."
   params = [
     {
       description: "Identity server host URL",
@@ -46,7 +46,7 @@ export class MarketoAction extends Hub.Action {
   async execute(request: Hub.ActionRequest) {
     // create a stateful object to manage the transaction
     const transaction = new MarketoTransaction()
-
+    console.log(JSON.stringify(request,undefined,4))
     // return the response from the transaction object
     return transaction.handleRequest(request)
   }
@@ -54,16 +54,29 @@ export class MarketoAction extends Hub.Action {
   async form() {
     const form = new Hub.ActionForm()
     form.fields = [{
-      label: "Campaign ID",
-      name: "campaignId",
-      required: true,
-      type: "string",
-    }, {
       label: "Lead Lookup Field",
       name: "lookupField",
       type: "string",
-      description: "Marketo field to use for lookup.",
+      description: "Marketo field to use for lookup",
       default: "email",
+      required: true,
+    }, {
+      label: "Add to Campaign ID (optional)",
+      name: "campaignId",
+      type: "string",
+      description: "Campaign ID to add the leads to, if any",
+      required: false,
+    }, {
+      label: "Add to Static List ID (optional)",
+      name: "addStaticList",
+      type: "string",
+      description: "Static List ID to add the leads to, if any",
+      required: true,
+    }, {
+      label: "Remove from Static List ID (optional)",
+      name: "removeStaticList",
+      type: "string",
+      description: "Static List ID to remove the leads from, if any.",
       required: true,
     }]
     return form

--- a/src/actions/marketo/marketo_transaction.ts
+++ b/src/actions/marketo/marketo_transaction.ts
@@ -26,40 +26,44 @@ export class MarketoTransaction {
     this.campaignIds = []
     this.addListIds = []
     this.removeListIds = []
-    let subactionIds = (request.formParams.subactionIds || '').split(/\s*,\s*/).filter(Boolean)
-    switch(request.formParams.subaction){
+    const subactionIds =
+      (request.formParams.subactionIds !== undefined ? request.formParams.subactionIds : "")
+      .split(/\s*,\s*/)
+      .filter(Boolean)
+    switch (request.formParams.subaction) {
       case undefined:
-        //The older version of the action assumed an "addToCampaign" subaction
-        this.campaignIds = [request.formParams.campaignId || ''].filter(Boolean) //Note singular parameter name
-        break;
-      case 'none':
-        if(subactionIds.length){
+        // The older version of the action assumed an "addToCampaign" subaction
+        this.campaignIds = [request.formParams.campaignId !== undefined ? request.formParams.campaignId : ""]
+          .filter(Boolean) // Note singular parameter name
+        break
+      case "none":
+        if (subactionIds.length === 0) {
           throw "Additional action of 'none' was selected, but additional action ID was provided"
         }
-      break;
-      case 'addCampaign':
-        if(!subactionIds.length){
+        break
+      case "addCampaign":
+        if (subactionIds.length > 0) {
           throw "'Add to campaign' was selected, but additional action ID was not provided"
         }
-      this.campaignIds = subactionIds
-      break;
-      case 'addList':
-        if(!subactionIds.length){
+        this.campaignIds = subactionIds
+        break
+      case "addList":
+        if (subactionIds.length > 0) {
           throw "'Add to list' was selected, but additional action ID was not provided"
         }
-      this.addListIds = subactionIds
-      break;
-      case 'removeList':
-        if(!subactionIds.length){
+        this.addListIds = subactionIds
+        break
+      case "removeList":
+        if (subactionIds.length > 0) {
           throw "'Remove from list' was selected, but additional action ID was not provided"
         }
-      this.removeListIds = subactionIds
-      break;
+        this.removeListIds = subactionIds
+        break
       default:
         throw "Unrecognized additional action type"
-      break
+        break
     }
-	
+
     this.lookupField = request.formParams.lookupField
     if (!this.lookupField) {
       throw "Missing Lookup Field."
@@ -165,22 +169,25 @@ export class MarketoTransaction {
       }
     })
 
-    for (let campaignId of this.campaignIds){
+    for (const campaignId of this.campaignIds) {
       const response = await this.marketo.campaign.request(campaignId, ids)
-      result.membershipErrors = result.membershipErrors.concat(response.errors || [])
+      result.membershipErrors =
+        result.membershipErrors.concat(response.errors !== undefined ? response.errors : [])
     }
 
-    for (let listId of this.addListIds){
+    for (const listId of this.addListIds) {
       const response = await this.marketo.list.addLeadsToList(listId, ids)
-      result.membershipErrors = result.membershipErrors.concat(response.errors || [])
+      result.membershipErrors =
+        result.membershipErrors.concat(response.errors !== undefined ? response.errors : [])
     }
 
-    for (let listId of this.removeListIds){
-      let leadIds = ids.map(obj=>obj.id)
+    for (const listId of this.removeListIds) {
+      const leadIds = ids.map((obj) => obj.id)
       // ^ Unlike the other two methods, removeLeadsFromList does not automatically pick the ID from an object
       // https://github.com/MadKudu/node-marketo/blob/master/lib/api/list.js#L38
       const response = await this.marketo.list.removeLeadsFromList(listId, leadIds)
-      result.membershipErrors = result.membershipErrors.concat(response.errors || [])
+      result.membershipErrors =
+        result.membershipErrors.concat(response.errors !== undefined ? response.errors : [])
     }
 
     return result

--- a/src/actions/marketo/marketo_transaction.ts
+++ b/src/actions/marketo/marketo_transaction.ts
@@ -55,6 +55,9 @@ export class MarketoTransaction {
         }
       this.removeListIds = subactionIds
       break;
+      default:
+        throw "Unrecognized additional action type"
+      break
     }
 	
     this.lookupField = request.formParams.lookupField
@@ -166,14 +169,17 @@ export class MarketoTransaction {
       const response = await this.marketo.campaign.request(campaignId, ids)
       result.membershipErrors = result.membershipErrors.concat(response.errors || [])
     }
-	
+
     for (let listId of this.addListIds){
       const response = await this.marketo.list.addLeadsToList(listId, ids)
       result.membershipErrors = result.membershipErrors.concat(response.errors || [])
     }
 
     for (let listId of this.removeListIds){
-      const response = await this.marketo.campaign.removeLeadsFromList(listId, ids)
+      let leadIds = ids.map(obj=>obj.id)
+      // ^ Unlike the other two methods, removeLeadsFromList does not automatically pick the ID from an object
+      // https://github.com/MadKudu/node-marketo/blob/master/lib/api/list.js#L38
+      const response = await this.marketo.list.removeLeadsFromList(listId, leadIds)
       result.membershipErrors = result.membershipErrors.concat(response.errors || [])
     }
 

--- a/src/actions/marketo/marketo_transaction.ts
+++ b/src/actions/marketo/marketo_transaction.ts
@@ -25,11 +25,11 @@ export class MarketoTransaction {
   async handleRequest(request: Hub.ActionRequest): Promise<Hub.ActionResponse> {
 
     this.campaignIds = (
-		request.formParams.campaignIds
-		|| request.formParams.campaignId //Support the old "single add" format as well
-		|| '').split(/\s*,\s*/).filter(Boolean)
-	this.addListIds = (request.formParams.addListIds || '').split(/\s*,\s*/).filter(Boolean)
-	this.removeListIds = (request.formParams.removeListIds || '').split(/\s*,\s*/).filter(Boolean)
+        request.formParams.campaignIds
+        || request.formParams.campaignId //Support the old "single add" format as well
+        || '').split(/\s*,\s*/).filter(Boolean)
+    this.addListIds = (request.formParams.addListIds || '').split(/\s*,\s*/).filter(Boolean)
+    this.removeListIds = (request.formParams.removeListIds || '').split(/\s*,\s*/).filter(Boolean)
     this.lookupField = request.formParams.lookupField
     if (!this.lookupField) {
       throw "Missing Lookup Field."

--- a/src/actions/marketo/marketo_transaction.ts
+++ b/src/actions/marketo/marketo_transaction.ts
@@ -37,24 +37,24 @@ export class MarketoTransaction {
           .filter(Boolean) // Note singular parameter name
         break
       case "none":
-        if (subactionIds.length === 0) {
+        if (subactionIds.length > 0) {
           throw "Additional action of 'none' was selected, but additional action ID was provided"
         }
         break
       case "addCampaign":
-        if (subactionIds.length > 0) {
+        if (subactionIds.length === 0) {
           throw "'Add to campaign' was selected, but additional action ID was not provided"
         }
         this.campaignIds = subactionIds
         break
       case "addList":
-        if (subactionIds.length > 0) {
+        if (subactionIds.length === 0) {
           throw "'Add to list' was selected, but additional action ID was not provided"
         }
         this.addListIds = subactionIds
         break
       case "removeList":
-        if (subactionIds.length > 0) {
+        if (subactionIds.length === 0) {
           throw "'Remove from list' was selected, but additional action ID was not provided"
         }
         this.removeListIds = subactionIds

--- a/src/actions/marketo/test_marketo.ts
+++ b/src/actions/marketo/test_marketo.ts
@@ -23,22 +23,6 @@ const sampleData = {
 describe(`${action.constructor.name} unit tests`, () => {
   describe("action", () => {
 
-    it("errors if there is no campaignId", () => {
-      const request = new Hub.ActionRequest()
-      request.type = Hub.ActionType.Query
-      request.params = {
-        url: "myurl",
-        clientID: "myclientID",
-        clientSecret: "myclientSecret",
-      }
-      request.formParams = {}
-      request.attachment = {
-        dataBuffer: Buffer.from(JSON.stringify(sampleData)),
-      }
-      return chai.expect(action.validateAndExecute(request)).to.eventually
-        .be.rejectedWith("Missing Campaign ID.")
-    })
-
     it("errors if there is no lookupField", () => {
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Query

--- a/src/actions/marketo/test_marketo.ts
+++ b/src/actions/marketo/test_marketo.ts
@@ -22,9 +22,9 @@ const sampleData = {
 
 describe(`${action.constructor.name} unit tests`, () => {
   describe("action", () => {
-	  
+
     it("errors if there is no subaction and no campaignId", () => {
-      //This is the old implicit mode
+      // This is the old implicit mode
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Query
       request.params = {
@@ -41,7 +41,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     })
 
     it("errors if subaction is 'none' and there is subactionIds", () => {
-      //This is the old implicit mode
+      // This is the old implicit mode
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Query
       request.params = {
@@ -50,8 +50,8 @@ describe(`${action.constructor.name} unit tests`, () => {
         clientSecret: "myclientSecret",
       }
       request.formParams = {
-        subaction:"none",
-        subactionIds:"123"
+        subaction: "none",
+        subactionIds: "123",
       }
       request.attachment = {
         dataBuffer: Buffer.from(JSON.stringify(sampleData)),
@@ -61,7 +61,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     })
 
     it("errors if subaction is not 'none' and there is no subactionIds", () => {
-      //This is the old implicit mode
+      // This is the old implicit mode
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Query
       request.params = {
@@ -70,8 +70,8 @@ describe(`${action.constructor.name} unit tests`, () => {
         clientSecret: "myclientSecret",
       }
       request.formParams = {
-        subaction:"addCampaign",
-        subactionIds:""
+        subaction: "addCampaign",
+        subactionIds: "",
       }
       request.attachment = {
         dataBuffer: Buffer.from(JSON.stringify(sampleData)),
@@ -81,7 +81,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     })
 
     it("errors if subaction is not recognized", () => {
-      //This is the old implicit mode
+      // This is the old implicit mode
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Query
       request.params = {
@@ -90,7 +90,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         clientSecret: "myclientSecret",
       }
       request.formParams = {
-        subaction:"somethingUnexpected"
+        subaction: "somethingUnexpected",
       }
       request.attachment = {
         dataBuffer: Buffer.from(JSON.stringify(sampleData)),

--- a/src/actions/marketo/test_marketo.ts
+++ b/src/actions/marketo/test_marketo.ts
@@ -22,6 +22,82 @@ const sampleData = {
 
 describe(`${action.constructor.name} unit tests`, () => {
   describe("action", () => {
+	  
+    it("errors if there is no subaction and no campaignId", () => {
+      //This is the old implicit mode
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Query
+      request.params = {
+        url: "myurl",
+        clientID: "myclientID",
+        clientSecret: "myclientSecret",
+      }
+      request.formParams = {}
+      request.attachment = {
+        dataBuffer: Buffer.from(JSON.stringify(sampleData)),
+      }
+      return chai.expect(action.validateAndExecute(request)).to.eventually
+        .be.rejected
+    })
+
+    it("errors if subaction is 'none' and there is subactionIds", () => {
+      //This is the old implicit mode
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Query
+      request.params = {
+        url: "myurl",
+        clientID: "myclientID",
+        clientSecret: "myclientSecret",
+      }
+      request.formParams = {
+        subaction:"none",
+        subactionIds:"123"
+      }
+      request.attachment = {
+        dataBuffer: Buffer.from(JSON.stringify(sampleData)),
+      }
+      return chai.expect(action.validateAndExecute(request)).to.eventually
+        .be.rejected
+    })
+
+    it("errors if subaction is not 'none' and there is no subactionIds", () => {
+      //This is the old implicit mode
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Query
+      request.params = {
+        url: "myurl",
+        clientID: "myclientID",
+        clientSecret: "myclientSecret",
+      }
+      request.formParams = {
+        subaction:"addCampaign",
+        subactionIds:""
+      }
+      request.attachment = {
+        dataBuffer: Buffer.from(JSON.stringify(sampleData)),
+      }
+      return chai.expect(action.validateAndExecute(request)).to.eventually
+        .be.rejected
+    })
+
+    it("errors if subaction is not recognized", () => {
+      //This is the old implicit mode
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Query
+      request.params = {
+        url: "myurl",
+        clientID: "myclientID",
+        clientSecret: "myclientSecret",
+      }
+      request.formParams = {
+        subaction:"somethingUnexpected"
+      }
+      request.attachment = {
+        dataBuffer: Buffer.from(JSON.stringify(sampleData)),
+      }
+      return chai.expect(action.validateAndExecute(request)).to.eventually
+        .be.rejected
+    })
 
     it("errors if there is no lookupField", () => {
       const request = new Hub.ActionRequest()

--- a/src/actions/marketo/test_marketo.ts
+++ b/src/actions/marketo/test_marketo.ts
@@ -14,11 +14,61 @@ const sampleData = {
   fields: {
     measures: [],
     dimensions: [
-      {name: "some.field", tags: ["sometag"]},
+      {label_short: "ID", name: "users.id", tags: ["user_id", "marketo:Account__c"]},
+      {label_short: "Email", name: "users.email", tags: ["email", "marketo:email"]},
+      {label_short: "Gender", name: "users.gender", tags: ["marketo:gender"]},
+      {label_short: "random", name: "users.random"},
     ],
   },
-  data: [{"some.field": {value: "value"}}],
+  data: [
+    {
+      "users.id": {value: 4653},
+      "users.email": {value: "zoraida.gregoire@example.com"},
+      "users.gender": {value: "f"},
+      "users.random": {value: 7},
+    },
+    {
+      "users.id": {value: 629},
+      "users.email": {value: "zola.summers@example.com"},
+      "users.gender": {value: "m"},
+      "users.random": {value: 4},
+    },
+    {
+      "users.id": {value: 6980},
+      "users.email": {value: "zoe.brady@example.com"},
+      "users.gender": {value: "f"},
+      "users.random": {value: 5},
+    },
+  ],
 }
+const sampleTypeParamsAttachment = {
+  type: Hub.ActionType.Query,
+  params: {
+    url: "myurl",
+    clientID: "myclientID",
+    clientSecret: "myclientSecret",
+  },
+  attachment: {
+    dataBuffer: Buffer.from(JSON.stringify(sampleData)),
+  },
+}
+const expectedLeadData = [
+  {
+    Account__c: 4653,
+    email: "zoraida.gregoire@example.com",
+    gender: "f",
+  },
+  {
+    Account__c: 629,
+    email: "zola.summers@example.com",
+    gender: "m",
+  },
+  {
+    Account__c: 6980,
+    email: "zoe.brady@example.com",
+    gender: "f",
+  },
+]
 
 describe(`${action.constructor.name} unit tests`, () => {
   describe("action", () => {
@@ -127,7 +177,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       }
       request.formParams = {
         campaignId: "1243",
-        lookupField: "email",
+        lookupField: "guid",
       }
       request.attachment = {
         dataBuffer: Buffer.from(JSON.stringify(sampleData)),
@@ -137,96 +187,141 @@ describe(`${action.constructor.name} unit tests`, () => {
         .be.rejectedWith("Marketo Lookup Field for lead not present in query.")
     })
 
-    it("sends all the data to Marketo", () => {
-      const request = new Hub.ActionRequest()
-      request.type = Hub.ActionType.Query
-      request.params = {
-        url: "myurl",
-        clientID: "myclientID",
-        clientSecret: "myclientSecret",
+    const leadIds = [{id: 1}, {id: 2}, {id: 3}]
+    const spies = [
+      async () => Promise.resolve({
+        success: true,
+        result: leadIds,
+      }),
+      async () => Promise.resolve({
+        success: true,
+        result: leadIds,
+      }),
+      async () => Promise.resolve({
+          success: true,
+        result: leadIds,
+      }),
+      async () => Promise.resolve({
+          success: true,
+      }),
+    ].map((fn) => sinon.spy(fn))
+    const spy = {
+      leadCreateOrUpdate: spies[0],
+      campaignRequest: spies[1],
+      listAddLeadsToList: spies[2],
+      listRemoveLeadsFromList: spies[3],
+    }
+
+    sinon.stub(MarketoTransaction.prototype, "marketoClientFromRequest").callsFake(() => {
+      return {
+        lead: {
+          createOrUpdate: spy.leadCreateOrUpdate,
+        },
+        campaign: {
+          request: spy.campaignRequest,
+        },
+        list: {
+          addLeadsToList: spy.listAddLeadsToList,
+          removeLeadsFromList: spy.listRemoveLeadsFromList,
+        },
       }
+    })
+
+    it("sends all the data to Marketo for the legacy request format", () => {
+      const request = new Hub.ActionRequest()
+      Object.assign(request, sampleTypeParamsAttachment)
       request.formParams = {
-        campaignId: "1243",
+        campaignId: "101",
         lookupField: "email",
       }
-      request.attachment = {
-        dataBuffer: Buffer.from(JSON.stringify({
-          fields: {
-            measures: [],
-            dimensions: [
-              {label_short: "ID", name: "users.id", tags: ["user_id", "marketo:Account__c"]},
-              {label_short: "Email", name: "users.email", tags: ["email", "marketo:email"]},
-              {label_short: "Gender", name: "users.gender", tags: ["marketo:gender"]},
-              {label_short: "random", name: "users.random"},
-            ],
-          },
-          data: [
-            {
-              "users.id": {value: 4653},
-              "users.email": {value: "zoraida.gregoire@gmail.com"},
-              "users.gender": {value: "f"},
-              "users.random": {value: 7},
-            },
-            {
-              "users.id": {value: 629},
-              "users.email": {value: "zola.summers@gmail.com"},
-              "users.gender": {value: "m"},
-              "users.random": {value: 4},
-            },
-            {
-              "users.id": {value: 6980},
-              "users.email": {value: "zoe.brady@gmail.com"},
-              "users.gender": {value: "f"},
-              "users.random": {value: 5},
-            },
-          ],
-        })),
-      }
 
-      const leadSpy = sinon.spy(async () => Promise.resolve({
-        success: true,
-        result: [{id: 1}, {id: 2}, {id: 3}],
-      }))
-      const requestSpy = sinon.spy(async () => Promise.resolve({
-        success: true,
-        result: [{id: 1}, {id: 2}, {id: 3}],
-      }))
+      spies.forEach((s) => s.resetHistory())
 
-      const stubClient = sinon.stub(MarketoTransaction.prototype, "marketoClientFromRequest").callsFake(() => {
-        return {
-          lead: {
-            createOrUpdate: leadSpy,
-          },
-          campaign: {
-            request: requestSpy,
-          },
-        }
-      })
       return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
-        chai.expect(leadSpy).to.have.been.calledWith([
-          {
-            Account__c: 4653,
-            email: "zoraida.gregoire@gmail.com",
-            gender: "f",
-          },
-          {
-            Account__c: 629,
-            email: "zola.summers@gmail.com",
-            gender: "m",
-          },
-          {
-            Account__c: 6980,
-            email: "zoe.brady@gmail.com",
-            gender: "f",
-          },
-        ], {lookupField: "email"})
-        chai.expect(requestSpy).to.have.been.calledWith("1243",
-          [{id: 1}, {id: 2}, {id: 3}])
-        stubClient.restore()
+        chai.expect(spy.leadCreateOrUpdate).to.have.been.calledWith(expectedLeadData, {lookupField: "email"})
+        chai.expect(spy.campaignRequest).to.have.been.calledWith(
+          "101",
+          leadIds,
+        )
       })
     })
 
-  })
+    it("sends all the data to Marketo for the 'none' subaction", () => {
+      const request = new Hub.ActionRequest()
+      Object.assign(request, sampleTypeParamsAttachment)
+      request.formParams = {
+        subaction: "none",
+        lookupField: "email",
+      }
+
+      spies.forEach((s) => s.resetHistory())
+
+      return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
+        chai.expect(spy.leadCreateOrUpdate).to.have.been.calledWith(expectedLeadData, {lookupField: "email"})
+      })
+    })
+
+    it("sends all the data to Marketo for 'addCampaign' subaction", () => {
+      const request = new Hub.ActionRequest()
+      Object.assign(request, sampleTypeParamsAttachment)
+      request.formParams = {
+        subaction: "addCampaign",
+        subactionIds: "202",
+        lookupField: "email",
+      }
+
+      spies.forEach((s) => s.resetHistory())
+
+      return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
+        chai.expect(spy.leadCreateOrUpdate).to.have.been.calledWith(expectedLeadData, {lookupField: "email"})
+        chai.expect(spy.campaignRequest).to.have.been.calledWith(
+          "202",
+          leadIds,
+        )
+      })
+    })
+
+    it("sends all the data to Marketo for 'addList' subaction", () => {
+      const request = new Hub.ActionRequest()
+      Object.assign(request, sampleTypeParamsAttachment)
+      request.formParams = {
+          subaction: "addList",
+        subactionIds: "303",
+        lookupField: "email",
+      }
+
+      spies.forEach((s) => s.resetHistory())
+
+      return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
+        chai.expect(spy.leadCreateOrUpdate).to.have.been.calledWith(expectedLeadData, {lookupField: "email"})
+        chai.expect(spy.listAddLeadsToList).to.have.been.calledWith(
+          "303",
+          leadIds,
+        )
+      })
+    })
+
+    it("sends all the data to Marketo for 'removeList' subaction", () => {
+      const request = new Hub.ActionRequest()
+      Object.assign(request, sampleTypeParamsAttachment)
+      request.formParams = {
+        subaction: "removeList",
+        subactionIds: "404",
+        lookupField: "email",
+      }
+
+      spies.forEach((s) => s.resetHistory())
+
+      return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
+        chai.expect(spy.leadCreateOrUpdate).to.have.been.calledWith(expectedLeadData, {lookupField: "email"})
+        chai.expect(spy.listRemoveLeadsFromList).to.have.been.calledWith(
+          "404",
+          [1, 2, 3],
+        )
+      })
+    })
+
+})
 
   describe("asJSON", () => {
     it("supported format is json_detail on lookerVersion 6.0 and below", (done) => {


### PR DESCRIPTION
PR adds additional modes to the Marketo action, specifically:
- Being able to update leads WITHOUT providing a campaign ID
- Being able to update leads and add them to a list
- Being able to update leads and remove them from a list

![image](https://user-images.githubusercontent.com/23034640/56385299-b4806400-61ec-11e9-8195-19a54a33ab4b.png)
