### PR TITLE
add liquid templates to filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "express-winston": "^2.4.0",
     "hipchatter": "^1.0.0",
     "jira-client": "^6.4.1",
+    "liquidjs": "^8.5.2",
     "mailchimp": "^1.2.0",
     "node-marketo-rest": "^0.7.0",
     "nodemailer": "^5.1.1",

--- a/src/actions/amazon/amazon_s3.ts
+++ b/src/actions/amazon/amazon_s3.ts
@@ -42,11 +42,7 @@ export class AmazonS3Action extends Hub.Action {
 
     const s3 = this.amazonS3ClientFromRequest(request)
 
-    const filename = request.formParams.filename || request.suggestedFilename()
-
-    if (!filename) {
-      throw new Error("Couldn't determine filename.")
-    }
+    const filename = await request.templatedFilename(request.formParams.filename)
 
     const bucket = request.formParams.bucket
 

--- a/src/actions/azure/azure_storage.ts
+++ b/src/actions/azure/azure_storage.ts
@@ -33,7 +33,7 @@ export class AzureStorageAction extends Hub.Action {
       throw "Need Azure container."
     }
 
-    const fileName = request.formParams.filename || request.suggestedFilename()
+    const fileName = await request.templatedFilename(request.formParams.filename)
     const container = request.formParams.container
 
     if (!fileName) {

--- a/src/actions/dropbox/dropbox.ts
+++ b/src/actions/dropbox/dropbox.ts
@@ -18,7 +18,7 @@ export class DropboxAction extends Hub.OAuthAction {
     params = []
 
   async execute(request: Hub.ActionRequest) {
-    const filename = request.formParams.filename
+    const filename = await request.templatedFilename(request.formParams.filename)
     const directory = request.formParams.directory
     const ext = request.attachment!.fileExtension
 

--- a/src/actions/google/google_cloud_storage.ts
+++ b/src/actions/google/google_cloud_storage.ts
@@ -39,11 +39,7 @@ export class GoogleCloudStorageAction extends Hub.Action {
       throw "Need Google Cloud Storage bucket."
     }
 
-    const filename = request.formParams.filename || request.suggestedFilename()
-
-    if (!filename) {
-      throw new Error("Couldn't determine filename.")
-    }
+    const filename = await request.templatedFilename(request.formParams.filename)
 
     const gcs = this.gcsClientFromRequest(request)
     const file = gcs.bucket(request.formParams.bucket)

--- a/src/actions/sendgrid/sendgrid.ts
+++ b/src/actions/sendgrid/sendgrid.ts
@@ -29,7 +29,7 @@ export class SendGridAction extends Hub.Action {
     if (!request.formParams.to) {
       throw "Needs a valid email address."
     }
-    const filename = request.formParams.filename || request.suggestedFilename() as string
+    const filename = await request.templatedFilename(request.formParams.filename)
     const plan = request.scheduledPlan
     const subject = request.formParams.subject || (plan && plan.title ? plan.title : "Looker")
     const from = request.formParams.from ? request.formParams.from : "Looker <noreply@lookermail.com>"

--- a/src/actions/sftp/sftp.ts
+++ b/src/actions/sftp/sftp.ts
@@ -32,7 +32,7 @@ export class SFTPAction extends Hub.Action {
         throw "Needs a valid SFTP address."
       }
       const data = request.attachment.dataBuffer
-      const fileName = request.formParams.filename || request.suggestedFilename() as string
+      const fileName = await request.templatedFilename(request.formParams.filename)
       const remotePath = Path.join(parsedUrl.pathname, fileName)
 
       client.put(data, remotePath)

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -1,5 +1,7 @@
 import * as Hub from "../../hub"
 
+import * as winston from "winston"
+
 import { WebClient } from "@slack/client"
 
 interface Channel {
@@ -29,6 +31,8 @@ https://github.com/looker/actions/blob/master/src/actions/slack/README.md`,
 
   async execute(request: Hub.ActionRequest) {
 
+    winston.info(`request: ${JSON.stringify(request)}`)
+
     if (!request.attachment || !request.attachment.dataBuffer) {
       throw "Couldn't get data from attachment."
     }
@@ -37,7 +41,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/README.md`,
       throw "Missing channel."
     }
 
-    const fileName = request.formParams.filename || request.suggestedFilename()
+    const fileName = await request.templatedFilename(request.formParams.filename)
 
     const options = {
       file: request.attachment.dataBuffer,

--- a/test/test.ts
+++ b/test/test.ts
@@ -12,6 +12,7 @@ winston.remove(winston.transports.Console)
 
 import "../src/actions/index"
 
+import "./test_action_request"
 import "./test_action_response"
 import "./test_actions"
 import "./test_server"

--- a/test/test_action_request.ts
+++ b/test/test_action_request.ts
@@ -1,0 +1,89 @@
+import * as chai from "chai"
+import * as sinon from "sinon"
+
+import * as sanitizeFilename from "sanitize-filename"
+
+import { ActionRequest} from "../src/hub"
+
+describe("ActionRequest template filename", () => {
+
+  const now = new Date()
+  let clock: any
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(now.getTime())
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  const request = new ActionRequest()
+  request.attachment = {
+    dataBuffer: Buffer.from("1,2,3,4", "utf8"),
+    fileExtension: "csv",
+  }
+  request.scheduledPlan = {
+    url: "looker_url",
+    title: "Looker_title",
+    query: {
+      id: 1,
+      model: "looker_model",
+      view: "looker_view",
+      fields: ["a", "b"],
+      pivots: ["pivot_a"],
+      fill_fields: null,
+      filter_expression: null,
+      filters: {
+        x: "xvalue",
+        y: "yvalue",
+      },
+      sorts: ["a"],
+      limit: "500",
+      column_limit: "10",
+      total: false,
+      row_total: null,
+      runtime: 10,
+      vis_config: null,
+      filter_config: null,
+      visible_ui_sections: null,
+      slug: null,
+      dynamic_fields: null,
+      client_id: null,
+      share_url: null,
+      url: "looker_url",
+      expanded_share_url: null,
+      query_timezone: "",
+      has_table_calculations: false,
+      can: {
+        run: true,
+      },
+    },
+  }
+
+  it("template works with template, a schedule plan and query", async () => {
+    const filename = await request.templatedFilename(`{{ title | downcase }}-{{ query.filters.x }}.csv`)
+    chai.expect(filename)
+      .to.equal("looker_title-xvalue.csv")
+  })
+
+  it("template works referring to a date format not from query", async () => {
+    const filename = await request.templatedFilename(`{{ "now" | date: "%Y-%m-%d" }}.csv`)
+    chai.expect(filename)
+      .to.equal(`${new Date().toISOString().slice(0, 10)}.csv`)
+  })
+
+  it("returns suggested without template", async () => {
+    const filename = await request.templatedFilename()
+    chai.expect(filename)
+      .to.equal(`Looker_title.csv`)
+  })
+
+  it("returns suggested without template schedulePlan", async () => {
+    const emptyRequest = new ActionRequest()
+
+    const filename = await emptyRequest.templatedFilename()
+    chai.expect(filename)
+      .to.equal(sanitizeFilename(`looker_file_${new Date().toISOString()}`))
+  })
+
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,6 +2653,11 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+liquidjs@^8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-8.5.2.tgz#b44071f48dfb7f7939d88c7912aee71bd1b4450d"
+  integrity sha512-ZeTeytJNkos0Xhbu3XeGEPbMBMhzJpr9ijIJzZr5FpWp7VS4t/+FDXMpxpKtzRaNc3ah30dhrSxVdCphOaNrlw==
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"


### PR DESCRIPTION
@wilg would love your 👀 . I'd like to add the ability to have templated / parameterized filenames in action hub. What do you think of using liquid (looker default template) and passing in the schedule plan for reference info? Ideally, Looker would pass more metadata that could be exposed (when the data was generated, dashboard filter values ...).