### PR TITLE
Update to JsonDetailLiteStream and use json:true to prevent errors

### DIFF
--- a/src/actions/webhook/webhook.ts
+++ b/src/actions/webhook/webhook.ts
@@ -13,7 +13,7 @@ export abstract class WebhookAction extends Hub.Action {
   usesStreaming = true
   supportedFormattings = [Hub.ActionFormatting.Unformatted]
   supportedVisualizationFormattings = [Hub.ActionVisualizationFormatting.Noapply]
-  supportedFormats = [Hub.ActionFormat.JsonDetail]
+  supportedFormats = [Hub.ActionFormat.JsonDetailLiteStream]
 
   async execute(request: Hub.ActionRequest) {
 
@@ -38,7 +38,7 @@ export abstract class WebhookAction extends Hub.Action {
 
     try {
       await request.stream(async (readable) => {
-        return req.post({ uri: providedUrl, body: readable } ).promise()
+        return req.post({ uri: providedUrl, body: readable, json: true } ).promise()
       })
       return new Hub.ActionResponse({ success: true })
     } catch (e) {


### PR DESCRIPTION
JsonDetailLiteStream can go above 5000 rows and actually be unlimited, and json:true should help with some cases of request-promise-native throwing a weird error when readable is null