### PR TITLE
Revert "Update to JsonDetailLiteStream and use json:true to prevent errors"

### DIFF
--- a/src/actions/webhook/webhook.ts
+++ b/src/actions/webhook/webhook.ts
@@ -13,7 +13,7 @@ export abstract class WebhookAction extends Hub.Action {
   usesStreaming = true
   supportedFormattings = [Hub.ActionFormatting.Unformatted]
   supportedVisualizationFormattings = [Hub.ActionVisualizationFormatting.Noapply]
-  supportedFormats = [Hub.ActionFormat.JsonDetailLiteStream]
+  supportedFormats = [Hub.ActionFormat.JsonDetail]
 
   async execute(request: Hub.ActionRequest) {
 
@@ -38,7 +38,7 @@ export abstract class WebhookAction extends Hub.Action {
 
     try {
       await request.stream(async (readable) => {
-        return req.post({ uri: providedUrl, body: readable, json: true } ).promise()
+        return req.post({ uri: providedUrl, body: readable } ).promise()
       })
       return new Hub.ActionResponse({ success: true })
     } catch (e) {


### PR DESCRIPTION
Reverts looker/actions#267

Going to come back and look at this later, causing issues with Zapier that I did not catch in testing