### PR TITLE
Change process env constant to hardcoded in mParticle action

### DIFF
--- a/src/actions/mparticle/mparticle_constants.ts
+++ b/src/actions/mparticle/mparticle_constants.ts
@@ -3,6 +3,7 @@ export const EVENT_TYPE = "custom_event"
 export const DEFAULT_EVENT_NAME = "looker_custom_event"
 export const DEFAULT_CUSTOM_EVENT_TYPE = "other"
 export const DEV_ENVIRONMENT = "development"
+export const MAX_EVENTS_PER_BATCH = 100
 export const PROD_ENVIRONMENT = "production"
 export const USER = "user_data"
 export const EVENT = "event_data"

--- a/src/actions/mparticle/mparticle_transaction.ts
+++ b/src/actions/mparticle/mparticle_transaction.ts
@@ -3,12 +3,18 @@ import * as Hub from "../../hub"
 import * as httpRequest from "request-promise-native"
 
 import {
-  DEFAULT_CUSTOM_EVENT_TYPE, DEFAULT_EVENT_NAME, DEV_ENVIRONMENT, EVENT, EVENT_TYPE, MP_API_URL, PROD_ENVIRONMENT, USER,
+  DEFAULT_CUSTOM_EVENT_TYPE,
+  DEFAULT_EVENT_NAME,
+  DEV_ENVIRONMENT,
+  EVENT,
+  EVENT_TYPE,
+  MAX_EVENTS_PER_BATCH,
+  MP_API_URL,
+  PROD_ENVIRONMENT,
+  USER,
 } from "./mparticle_constants"
 import { MparticleEventMaps, MparticleEventTags, MparticleUserMaps, MparticleUserTags } from "./mparticle_enums"
 import { mparticleErrorCodes } from "./mparticle_error_codes"
-
-const maxEventsPerBatch = process.env.MAX_EVENTS_PER_BATCH
 
 import { LookmlModelExploreField as ExploreField } from "../../api_types/lookml_model_explore_field"
 
@@ -71,7 +77,7 @@ export class MparticleTransaction {
         },
         onRow: (row) => {
           rows.push(row)
-          if (rows.length === Number(maxEventsPerBatch)) {
+          if (rows.length === MAX_EVENTS_PER_BATCH) {
             this.sendChunk(rows, mapping).catch((e) => {
               throw e
             })


### PR DESCRIPTION
@phillipperalez could you please confirm if this env var was set on merge initially? I'm not sure the process for getting the variables set, but the client was running into issues when trying to send data > 100 of the batch size. This PR removes the need for the constant, because the API on mParticle's end is fixed and not subject to change. Thanks!