### PR TITLE
Fix streaming pivot errors

### DIFF
--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -319,7 +319,7 @@ export class ActionRequest {
       let rows = 0
       this.stream(async (readable) => {
         oboe(readable)
-          .node("data.*", this.safeOboe(readable, reject, (row) => {
+          .node("!.data.*", this.safeOboe(readable, reject, (row) => {
             rows++
             callbacks.onRow(row)
           }))

--- a/test/test.ts
+++ b/test/test.ts
@@ -14,6 +14,7 @@ import "../src/actions/index"
 
 import "./test_action_response"
 import "./test_actions"
+import "./test_json_detail_stream"
 import "./test_server"
 import "./test_smoke"
 

--- a/test/test_json_detail_stream.ts
+++ b/test/test_json_detail_stream.ts
@@ -1,0 +1,38 @@
+import * as chai from "chai"
+
+import * as Hub from "../src/hub"
+import { ActionRequest } from "../src/hub"
+
+describe("Hub.ActionRequest", () => {
+  describe("Hub.ActionRequest.streamJsonDetail", () => {
+    it("Can stream with nested data objects",  async () => {
+      const req = new ActionRequest()
+      // Very incomplete json_detail response
+      const detail = {
+        pivots: [{key: "k", data: {value: "hi"}}],
+        fields: {dimensions: [{name: "id"}]},
+        data: [{id: {value: "bob"}}],
+      }
+      const buf = Buffer.from(JSON.stringify(detail))
+      req.attachment = {
+        dataBuffer: buf,
+      }
+      let fieldset: Hub.Field[] = []
+      return new Promise<void>(async (res, rej) => {
+        await req.streamJsonDetail({
+          onFields: (fields) => {
+            fieldset = Hub.allFields(fields)
+            chai.expect(fieldset.length).to.equal(1)
+          },
+          onRow: (row) => {
+            chai.expect(fieldset.length).to.equal(1)
+            chai.expect(row).to.deep.equal({id: {value: "bob"}})
+            res()
+          },
+        }).catch((err) => {
+          rej(err)
+        })
+      })
+    }).timeout(10000)
+  })
+})


### PR DESCRIPTION
We need to only care about the top level data key for onRow calls in json_detail formats