### PR TITLE
Do not allow Azure to log access keys

### DIFF
--- a/src/actions/azure/azure_storage.ts
+++ b/src/actions/azure/azure_storage.ts
@@ -95,7 +95,14 @@ export class AzureStorageAction extends Hub.Action {
   }
 
   private azureClientFromRequest(request: Hub.ActionRequest) {
-    return azure.createBlobService(request.params.account!, request.params.accessKey!)
+    try {
+      return azure.createBlobService(request.params.account!, request.params.accessKey!)
+    } catch (err) {
+      if (err && err.toString().includes("base64")) {
+        throw "The provided Account Key is not a valid base64 string"
+      }
+      throw "Error making Azure client. Storage Account and Access Key settings may be incorrect"
+    }
   }
 
 }


### PR DESCRIPTION
Fixed a case where incorrectly formatted keys lead to key disclosure in actionhub logs