### PR TITLE
add addAction to AmazonS3

### DIFF
--- a/src/actions/amazon/amazon_s3.ts
+++ b/src/actions/amazon/amazon_s3.ts
@@ -101,3 +101,4 @@ export class AmazonS3Action extends Hub.Action {
   }
 
 }
+Hub.addAction(new AmazonS3Action())


### PR DESCRIPTION
1 line was missing in this file, and AmazonS3 wasn't available on Admin / Actions Panel.
With this one, we can add a IAM User which can read S3 buckets, and have a list of all the buckets when the user want to send a Dashboard or a look.