### PR TITLE
allow legacy slack action to post to private channels

### DIFF
--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -16,7 +16,7 @@ export class SlackAttachmentAction extends Hub.Action {
     label: "Slack API Token",
     required: true,
     description: `A Slack API token that includes the permissions "channels:read", \
-"users:read", and "files:write:user". You can follow the instructions to get a token at \
+"users:read", "groups:read", and "files:write:user". Follow the instructions to get a token at \
 https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/README.md`,
     sensitive: true,
   }]
@@ -30,7 +30,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
     const form = new Hub.ActionForm()
 
     try {
-      form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request), true)
+      form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request))
     } catch (e) {
       form.error = displayError[e.message] || e
     }

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -82,7 +82,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
     }
 
     try {
-      form.fields = form.fields.concat(await getDisplayedFormFields(client, false))
+      form.fields = form.fields.concat(await getDisplayedFormFields(client))
     } catch (e) {
       return this.loginForm(request, form)
     }

--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -57,25 +57,6 @@ describe(`slack/utils unit tests`, () => {
         it("returns correct channels", (done) => {
             const slackClient = new WebClient("token")
             sinon.stub(slackClient.conversations, "list").callsFake((filters: any) => filters.cursor ?
-                {
-                    ok: true,
-                    channels: [
-                        {id: "3", name: "C", is_member: true},
-                        {id: "4", name: "D", is_member: true},
-                    ],
-                } :
-                {
-                    ok: true,
-                    channels: [
-                        {id: "1", name: "A", is_member: true},
-                        {id: "2", name: "B", is_member: true},
-                    ],
-                    response_metadata: {
-                        next_cursor: "cursor",
-                    },
-                },
-            )
-            sinon.stub(slackClient.channels, "list").callsFake((filters: any) => filters.cursor ?
               {
                   ok: true,
                   channels: [
@@ -112,7 +93,7 @@ describe(`slack/utils unit tests`, () => {
                         next_cursor: "cursor",
                     },
                 })
-            const result = getDisplayedFormFields(slackClient, true)
+            const result = getDisplayedFormFields(slackClient)
             chai.expect(result).to.eventually.deep.equal([
                 {
                     description: "Name of the Slack channel you would like to post to.",

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -10,14 +10,13 @@ interface Channel {
     label: string,
 }
 
-const _usableChannels = async (slack: WebClient, legacy: boolean): Promise<Channel[]> => {
+const _usableChannels = async (slack: WebClient): Promise<Channel[]> => {
     const options: any = {
         types: "public_channel,private_channel",
         exclude_archived: true,
-        exclude_members: true,
         limit: API_LIMIT_SIZE,
     }
-    const channelList: any = legacy ? slack.channels.list : slack.conversations.list
+    const channelList: any = slack.conversations.list
     const pageLoaded = async (accumulatedChannels: any[], response: any): Promise<any[]> => {
         const mergedChannels = accumulatedChannels.concat(response.channels)
 
@@ -60,15 +59,15 @@ const usableDMs = async (slack: WebClient): Promise<Channel[]> => {
     return users.map((user: any) => ({id: user.id, label: `@${user.name}`}))
 }
 
-const usableChannels = async (slack: WebClient, legacy: boolean): Promise<Channel[]> => {
-    let channels = await _usableChannels(slack, legacy)
+const usableChannels = async (slack: WebClient): Promise<Channel[]> => {
+    let channels = await _usableChannels(slack)
     channels = channels.concat(await usableDMs(slack))
     channels.sort((a, b) => ((a.label < b.label) ? -1 : 1 ))
     return channels
 }
 
-export const getDisplayedFormFields = async (slack: WebClient, legacy: boolean): Promise<ActionFormField[]> => {
-    const channels = await usableChannels(slack, legacy)
+export const getDisplayedFormFields = async (slack: WebClient): Promise<ActionFormField[]> => {
+    const channels = await usableChannels(slack)
     return [
         {
             description: "Name of the Slack channel you would like to post to.",


### PR DESCRIPTION
This adds private channel support to the legacy slack action. Additionally, it enables private channel support to customer-hosted instances via the legacy slack action.

This undoes most of the changes in https://github.com/looker/actions/pull/279 which introduced this due to token confusion. `xoxp` vs `xoxb` token usage can be handled in documentation.

fixes: https://github.com/looker/actions/issues/227