### PR TITLE
slack: fallback to first workspace

### DIFF
--- a/src/actions/slack/slack_client_manager.ts
+++ b/src/actions/slack/slack_client_manager.ts
@@ -38,14 +38,25 @@ export class SlackClientManager {
                 }
             }
             if (supportMultiWs && Array.isArray(json)) {
-                this.selectedInstallId = request.formParams.workspace
                 this.clients = (JSON.parse(stateJson) as WorkspaceAwareStateJson[])
                     .reduce((accumulator, stateJsonItem) => {
+                        const ws = stateJsonItem.install_id
                         if (stateJsonItem.token) {
-                            accumulator[stateJsonItem.install_id] = makeSlackClient(stateJsonItem.token)
+                            accumulator[ws] = makeSlackClient(stateJsonItem.token)
                         }
                         return accumulator
                     }, {} as { [key: string]: WebClient })
+
+                if (request.formParams.workspace) {
+                    this.selectedInstallId = request.formParams.workspace
+                } else {
+                    /**
+                     * To fallback to the first client if there isn't any selected.
+                     * This is to allow existing schedules to work without the user has to
+                     * go back to the scheduler modal to select the workspace.
+                     */
+                    this.selectedInstallId = Object.keys(this.clients)[0]
+                }
             } else {
                 this.selectedInstallId = PLACEHOLDER_WORKSPACE
                 this.clients = {[PLACEHOLDER_WORKSPACE]: makeSlackClient(stateJson)}

--- a/src/actions/slack/test_slack.ts
+++ b/src/actions/slack/test_slack.ts
@@ -371,17 +371,18 @@ describe(`${action.constructor.name} tests`, () => {
         return chai.expect(form).to.eventually.deep.equal(response)
       })
 
-       it("doesn't have a selected workspace", () => {
-        const request = new Hub.ActionRequest()
-        request.lookerVersion = MULTI_WORKSPACE_SUPPORTED_VERSION
-        request.params = { state_json: JSON.stringify([{ install_id: "ws1", token: "someToken"}]) }
+       it("doesn't have a selected workspace default to the first one", () => {
+         const response = new Hub.ActionResponse({success: true})
 
-        const form = action.execute(request)
+         handleExecuteStub = sinon.stub(utils, "handleExecute").returns(Promise.resolve(response))
 
-        return chai.expect(form).to.eventually.deep.equal(new Hub.ActionResponse(
-            {success: false, message: "You must connect to a Slack workspace first."},
-            ),
-        )
+         const request = new Hub.ActionRequest()
+         request.lookerVersion = MULTI_WORKSPACE_SUPPORTED_VERSION
+         request.params = { state_json: JSON.stringify([{ install_id: "ws1", token: "someToken"}]) }
+
+         const form = action.execute(request)
+
+         return chai.expect(form).to.eventually.deep.equal(response)
       })
 
        it("uses the selected workspace if multiple ws is given", () => {

--- a/src/actions/slack/test_slack_client_manager.ts
+++ b/src/actions/slack/test_slack_client_manager.ts
@@ -96,10 +96,44 @@ describe("SlackClientManager", () => {
             })
         })
 
-        describe("has fault tolerence for str state json", () => {
+        describe("has fault tolerance for json str state json", () => {
             const request = new Hub.ActionRequest()
             request.lookerVersion = MULTI_WORKSPACE_SUPPORTED_VERSION
             request.params.state_json = JSON.stringify("token1")
+
+            it("hasAnyClients works", () => {
+                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
+                const clientManager = new SlackClientManager(request)
+                chai.expect(clientManager.hasAnyClients()).to.equals(true)
+            })
+            it("getClients works", () => {
+                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
+                const clientManager = new SlackClientManager(request)
+                const result = clientManager.getClients()
+                chai.expect(result).to.deep.equals(["stubbed"])
+            })
+            it("hasSelectedClient works", () => {
+                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
+                const clientManager = new SlackClientManager(request)
+                chai.expect(clientManager.hasSelectedClient()).to.eq(true)
+            })
+            it("getSelectedClient works", () => {
+                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
+                const clientManager = new SlackClientManager(request)
+                chai.expect(clientManager.getSelectedClient()).to.equals("stubbed")
+            })
+            it("getClient works", () => {
+                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
+                const clientManager = new SlackClientManager(request)
+                chai.expect(clientManager.getClient("WS1")).to.equals(undefined)
+                chai.expect(clientManager.getClient(PLACEHOLDER_WORKSPACE)).to.equals("stubbed")
+            })
+        })
+
+        describe("has fault tolerance for str state json", () => {
+            const request = new Hub.ActionRequest()
+            request.lookerVersion = MULTI_WORKSPACE_SUPPORTED_VERSION
+            request.params.state_json = "token1"
 
             it("hasAnyClients works", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
@@ -149,12 +183,12 @@ describe("SlackClientManager", () => {
             it("hasSelectedClient works", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
                 const clientManager = new SlackClientManager(request)
-                chai.expect(clientManager.hasSelectedClient()).to.eq(false)
+                chai.expect(clientManager.hasSelectedClient()).to.eq(true)
             })
             it("getSelectedClient works", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
                 const clientManager = new SlackClientManager(request)
-                chai.expect(clientManager.getSelectedClient()).to.eq(undefined)
+                chai.expect(clientManager.getSelectedClient()).to.eq("stubbed")
             })
             it("getClient works", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
@@ -185,7 +219,7 @@ describe("SlackClientManager", () => {
             it("hasSelectedClient works", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
                 const clientManager = new SlackClientManager(request)
-                chai.expect(clientManager.hasSelectedClient()).to.eq(false)
+                chai.expect(clientManager.hasSelectedClient()).to.eq(true)
             })
 
             it("hasSelectedClient works - with selected WS", () => {
@@ -196,15 +230,15 @@ describe("SlackClientManager", () => {
             })
 
             it("getSelectedClient works", () => {
-                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").returns("stubbed")
+                stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").callsFake((token) => `stubbed-${token}`)
                 const clientManager = new SlackClientManager(request)
-                chai.expect(clientManager.getSelectedClient()).to.eq(undefined)
+                chai.expect(clientManager.getSelectedClient()).to.eq("stubbed-token1")
             })
             it("getSelectedClient works - with selected WS", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").callsFake((token) => `stubbed-${token}`)
-                const hasSelecteWSReq = Object.assign({}, request, { formParams: { workspace: "WS1"}})
+                const hasSelecteWSReq = Object.assign({}, request, { formParams: { workspace: "WS2"}})
                 const clientManager = new SlackClientManager(hasSelecteWSReq)
-                chai.expect(clientManager.getSelectedClient()).to.eq("stubbed-token1")
+                chai.expect(clientManager.getSelectedClient()).to.eq("stubbed-token2")
             })
             it("getClient works", () => {
                 stubClient = sinon.stub(_SlackClientManager, "makeSlackClient").callsFake((token) => `stubbed-${token}`)


### PR DESCRIPTION
To allow existing schedules to work without the user has to go back to the scheduler modal to select the workspace.