### PR TITLE
Infer file extension for streaming formats

### DIFF
--- a/src/actions/sendgrid/sendgrid.ts
+++ b/src/actions/sendgrid/sendgrid.ts
@@ -29,7 +29,7 @@ export class SendGridAction extends Hub.Action {
     if (!request.formParams.to) {
       throw "Needs a valid email address."
     }
-    const filename = request.formParams.filename || request.suggestedFilename() as string
+    const filename = request.formParams.filename || request.suggestedFilename()
     const plan = request.scheduledPlan
     const subject = request.formParams.subject || (plan && plan.title ? plan.title : "Looker")
     const from = request.formParams.from ? request.formParams.from : "Looker <noreply@lookermail.com>"

--- a/src/actions/sftp/sftp.ts
+++ b/src/actions/sftp/sftp.ts
@@ -32,7 +32,7 @@ export class SFTPAction extends Hub.Action {
         throw "Needs a valid SFTP address."
       }
       const data = request.attachment.dataBuffer
-      const fileName = request.formParams.filename || request.suggestedFilename() as string
+      const fileName = request.formParams.filename || request.suggestedFilename()
       const remotePath = Path.join(parsedUrl.pathname, fileName)
 
       client.put(data, remotePath)

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -356,11 +356,11 @@ export class ActionRequest {
         return sanitizeFilename(`looker_file_${Date.now()}.${this.attachment.fileExtension}`)
       }
     } else {
-      if (this.params.format) {
+      if (this.formParams.format) {
         if (this.scheduledPlan && this.scheduledPlan.title) {
-          return sanitizeFilename(`${this.scheduledPlan.title}.${formatToFileExtension(this.params.format)}`)
+          return sanitizeFilename(`${this.scheduledPlan.title}.${formatToFileExtension(this.formParams.format)}`)
         } else {
-          return sanitizeFilename(`looker_file_${Date.now()}.${formatToFileExtension(this.params.format)}`)
+          return sanitizeFilename(`looker_file_${Date.now()}.${formatToFileExtension(this.formParams.format)}`)
         }
       }
     }

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -355,15 +355,15 @@ export class ActionRequest {
       } else {
         return sanitizeFilename(`looker_file_${Date.now()}.${this.attachment.fileExtension}`)
       }
-    } else {
-      if (this.formParams.format) {
-        if (this.scheduledPlan && this.scheduledPlan.title) {
-          return sanitizeFilename(`${this.scheduledPlan.title}.${formatToFileExtension(this.formParams.format)}`)
-        } else {
-          return sanitizeFilename(`looker_file_${Date.now()}.${formatToFileExtension(this.formParams.format)}`)
-        }
+    } else if (this.formParams.format) {
+      if (this.scheduledPlan && this.scheduledPlan.title) {
+        return sanitizeFilename(`${this.scheduledPlan.title}.${formatToFileExtension(this.formParams.format)}`)
+      } else {
+        return sanitizeFilename(`looker_file_${Date.now()}.${formatToFileExtension(this.formParams.format)}`)
       }
     }
+    winston.warn("Couldn't infer file extension from action request, using default filename scheme")
+    return sanitizeFilename(`looker_file_${Date.now()}`)
   }
 
   /** creates a truncated message with a max number of lines and max number of characters with Title, Url,

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -5,7 +5,7 @@ import * as sanitizeFilename from "sanitize-filename"
 import * as semver from "semver"
 import { PassThrough, Readable } from "stream"
 import * as winston from "winston"
-import { truncateString } from "./utils"
+import { formatToFileExtension, truncateString } from "./utils"
 
 import {
   DataWebhookPayload,
@@ -354,6 +354,14 @@ export class ActionRequest {
         return sanitizeFilename(`${this.scheduledPlan.title}.${this.attachment.fileExtension}`)
       } else {
         return sanitizeFilename(`looker_file_${Date.now()}.${this.attachment.fileExtension}`)
+      }
+    } else {
+      if (this.params.format) {
+        if (this.scheduledPlan && this.scheduledPlan.title) {
+          return sanitizeFilename(`${this.scheduledPlan.title}.${formatToFileExtension(this.params.format)}`)
+        } else {
+          return sanitizeFilename(`looker_file_${Date.now()}.${formatToFileExtension(this.params.format)}`)
+        }
       }
     }
   }

--- a/src/hub/utils.ts
+++ b/src/hub/utils.ts
@@ -9,3 +9,12 @@ export function truncateString(s: string, limit: number, split = "\n") {
   }
   return s
 }
+
+export function formatToFileExtension(format: string) {
+  const JSON_LIKE = ['json', 'json_label', 'inline_json', 'json_detail']
+  if (JSON_LIKE.includes(format)) {
+    return 'json'
+  } else {
+    return format
+  }
+}

--- a/src/hub/utils.ts
+++ b/src/hub/utils.ts
@@ -11,9 +11,9 @@ export function truncateString(s: string, limit: number, split = "\n") {
 }
 
 export function formatToFileExtension(format: string) {
-  const JSON_LIKE = ['json', 'json_label', 'inline_json', 'json_detail']
+  const JSON_LIKE = ["json", "json_label", "inline_json", "json_detail"]
   if (JSON_LIKE.indexOf(format) !== -1) {
-    return 'json'
+    return "json"
   } else {
     return format
   }

--- a/src/hub/utils.ts
+++ b/src/hub/utils.ts
@@ -12,7 +12,7 @@ export function truncateString(s: string, limit: number, split = "\n") {
 
 export function formatToFileExtension(format: string) {
   const JSON_LIKE = ['json', 'json_label', 'inline_json', 'json_detail']
-  if (JSON_LIKE.includes(format)) {
+  if (JSON_LIKE.indexOf(format) !== -1) {
     return 'json'
   } else {
     return format

--- a/test/test_action_request.ts
+++ b/test/test_action_request.ts
@@ -46,4 +46,28 @@ describe("ActionRequest", () => {
     chai.expect(result.lookerVersion).to.equal(semver.valid("7.3.4561"))
   })
 
+  it("ActionRequest.suggestedFilename parses formParams if there's no attachment", () => {
+    const formats = ["csv", "xlsx", "html", "txt", "json", "json_label", "inline_json", "json_detail"]
+    const expectedExtensions = [".csv", ".xlsx", ".html", ".txt", ".json", ".json", ".json", ".json"]
+
+    formats.map((format, i) => {
+      const req = mockReq({
+        headers: {
+          "user-agent": "LookerOutgoingWebhook/7.3.0",
+          "x-looker-webhook-id": "123",
+          "x-looker-instance": "instanceId1",
+        },
+        body: {
+          form_params: {format},
+          scheduled_plan: {title: "Orders by County"},
+        },
+      })
+
+      // @ts-ignore
+      req.header = (name: string): string | string[] | undefined => req.headers[name]
+
+      const result = ActionRequest.fromRequest(req)
+      chai.expect(result.suggestedFilename()).to.equal(`Orders by County${expectedExtensions[i]}`)
+    })
+  })
 })


### PR DESCRIPTION
This change proposes inferring the file extension for webhook payloads that don't have the `attachment` field (equivalent to streaming formats).

One use-case this solves is when customers attempt to send a query result as an Excel file to Slack. The Slack API is dependent on an `filename` field to determine file type, and absent this field, what gets posted is a file called `Untitled` that shows up as a `zip` instead of a `xlsx` file.