### PR TITLE
Fix lint errors (remove unnecessary type assertions)

### DIFF
--- a/src/actions/sendgrid/sendgrid.ts
+++ b/src/actions/sendgrid/sendgrid.ts
@@ -29,7 +29,7 @@ export class SendGridAction extends Hub.Action {
     if (!request.formParams.to) {
       throw "Needs a valid email address."
     }
-    const filename = request.formParams.filename || request.suggestedFilename() as string
+    const filename = request.formParams.filename || request.suggestedFilename()
     const plan = request.scheduledPlan
     const subject = request.formParams.subject || (plan && plan.title ? plan.title : "Looker")
     const from = request.formParams.from ? request.formParams.from : "Looker <noreply@lookermail.com>"

--- a/src/actions/sftp/sftp.ts
+++ b/src/actions/sftp/sftp.ts
@@ -32,7 +32,7 @@ export class SFTPAction extends Hub.Action {
         throw "Needs a valid SFTP address."
       }
       const data = request.attachment.dataBuffer
-      const fileName = request.formParams.filename || request.suggestedFilename() as string
+      const fileName = request.formParams.filename || request.suggestedFilename()
       const remotePath = Path.join(parsedUrl.pathname, fileName)
 
       client.put(data, remotePath)


### PR DESCRIPTION
Removes a few linting errors that ended up breaking the build

```
$ ./node_modules/.bin/tslint -c tslint.json 'src/**/*.ts' 'bin/**/*.ts' 'test/**/*.ts' -p tsconfig.json
ERROR: /home/travis/build/looker/actions/src/actions/sendgrid/sendgrid.ts[32, 53]: This assertion is unnecessary since it does not change the type of the expression.
ERROR: /home/travis/build/looker/actions/src/actions/sftp/sftp.ts[35, 55]: This assertion is unnecessary since it does not change the type of the expression.
error Command failed with exit code 2.
```