### PR TITLE
Sheets remove return call in flushing rows

### DIFF
--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -203,19 +203,19 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                         })
                     }
                 }).on("end", async () => {
-                    // @ts-ignore
-                    if (requestBody.requests.length > 0) {
-                        await mutex.runExclusive(async () => {
+                    await mutex.runExclusive(async () => {
+                        // @ts-ignore
+                        if (requestBody.requests.length > MAX_REQUEST_BATCH) {
                             await this.flush(requestBody, sheet, spreadsheetId).then(() => {
                                 winston.info(`Google Sheets Streamed ${rowCount} rows including headers`)
                                 resolve()
                             }).catch((e: any) => {
                                 reject(e)
                             })
-                        }).catch((e: any) => {
-                            reject(e)
-                        })
-                    }
+                        }
+                    }).catch((e: any) => {
+                        reject(e)
+                    })
                 }).on("error", (e: any) => {
                     winston.error(e)
                     reject(e)

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -189,16 +189,15 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                     if (requestBody.requests.length > MAX_REQUEST_BATCH) {
                         await mutex.runExclusive(async () => {
                             // @ts-ignore
-                            if (requestBody.requests.length < MAX_REQUEST_BATCH) {
-                                return
+                            if (requestBody.requests.length > MAX_REQUEST_BATCH) {
+                                const requestCopy: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {}
+                                Object.assign(requestCopy, requestBody)
+                                requestBody.requests = []
+                                await this.flush(requestCopy, sheet, spreadsheetId).catch((e: any) => {
+                                    winston.error(e)
+                                    reject(e)
+                                })
                             }
-                            const requestCopy: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {}
-                            Object.assign(requestCopy, requestBody)
-                            requestBody.requests = []
-                            await this.flush(requestCopy, sheet, spreadsheetId).catch((e: any) => {
-                                winston.error(e)
-                                reject(e)
-                            })
                         }).catch((e: any) => {
                             reject(e)
                         })

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -205,7 +205,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                 }).on("end", async () => {
                     await mutex.runExclusive(async () => {
                         // @ts-ignore
-                        if (requestBody.requests.length > MAX_REQUEST_BATCH) {
+                        if (requestBody.requests.length > 0) {
                             await this.flush(requestBody, sheet, spreadsheetId).then(() => {
                                 winston.info(`Google Sheets Streamed ${rowCount} rows including headers`)
                                 resolve()


### PR DESCRIPTION
There is a race condition where return can be called before the streaming function is done.