### PR TITLE
Fix to listing deleted folders in Drive/Sheet Forms

### DIFF
--- a/src/actions/google/drive/google_drive.ts
+++ b/src/actions/google/drive/google_drive.ts
@@ -81,8 +81,7 @@ export class GoogleDriveAction extends Hub.OAuthAction {
             fields: "files(id,name,parents),nextPageToken",
             orderBy: "recency desc",
             pageSize: 1000,
-            q: `mimeType='application/vnd.google-apps.folder'`,
-            trashed: false,
+            q: `mimeType='application/vnd.google-apps.folder' and trashed=false`,
             spaces: "drive",
           }
           if (request.formParams.drive !== undefined && request.formParams.drive !== "mydrive") {


### PR DESCRIPTION
Drive/Sheet file list should have trashed: false in q param