### PR TITLE
Make sure quotes properly formatted for CSV lines

### DIFF
--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -173,6 +173,10 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                             reject(e)
                         })
                     }
+                    const lineData = line.map((v: any) => {
+                        v = (v as string).replace(/\"/g, "\"\"")
+                        return `"${v}"`
+                    }).join(",") as string
                     // @ts-ignore
                     requestBody.requests.push({
                         pasteData: {
@@ -181,7 +185,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                                 columnIndex: 0,
                                 rowIndex,
                             },
-                            data: line.map((v: any) => `"${v}"` ).join(",") as string,
+                            data: lineData,
                             delimiter: ",",
                             type: "PASTE_NORMAL",
                         },

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -173,9 +173,10 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                             reject(e)
                         })
                     }
-                    const lineData = line.map((v: any) => {
-                        v = (v as string).replace(/\"/g, "\"\"")
-                        return `"${v}"`
+                    // Sanitize line data and properly encapsulate string formatting for CSV lines
+                    const lineData = line.map((record: string) => {
+                        record = record.replace(/\"/g, "\"\"")
+                        return `"${record}"`
                     }).join(",") as string
                     // @ts-ignore
                     requestBody.requests.push({


### PR DESCRIPTION
Before this change a record like `This tricky",string` would be sent incorrectly as `"This tricky",string"` which is invalid CSV. This PR reformat all `"` in strings to be correct `""` - making the example `This tricky"",string` and correct CSV