### PR TITLE
Fix Tests and Add Overwrite to GCS

### DIFF
--- a/src/actions/auger/test_auger_train.ts
+++ b/src/actions/auger/test_auger_train.ts
@@ -139,7 +139,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       stubPoller = sinon.stub(action as any, "startPoller")
       stubStartProject = sinon.stub(action as any, "startProject")
       stubUploadToS3 = sinon.stub(action as any, "uploadToS3")
-      sinon.stub(Date, "now").returns(now)
+      const stubDate = sinon.stub(Date, "now").returns(now)
       const augerURL = "https://app.auger.ai/api/v1"
       const rawName = "looker_file"
       const fileName = `${rawName}_${Date.now()}`
@@ -174,7 +174,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       }
 
       return chai.expect(action.execute(request))
-        .to.be.fulfilled
+        .to.be.fulfilled.and.notify(stubDate.restore)
         .then(() => {
           chai.expect(stubPoller, "stubPoller").to.have.been.called
           chai.expect(stubUploadToS3, "stubUploadToS3").to.have.been.calledWithMatch(records, url)
@@ -199,29 +199,59 @@ describe(`${action.constructor.name} unit tests`, () => {
       request.params.api_token = "token"
       const form = action.validateAndFetchForm(request)
 
-      chai.expect(form).to.eventually.deep.equal({
+      return chai.expect(form).to.eventually.deep.equal({
         fields: [
           {
-            name: "model_type",
-            label: "Model Type",
-            type: "select",
-            default: "classification",
+            description: "The Auger project to use.",
+            label: "Project Name",
+            name: "project_name",
             required: true,
-            options: [
-              { name: "classification", label: "Classification" },
-              { name: "regression", label: "Regression" },
-            ],
+            type: "string",
           },
           {
-            name: "project_name",
-            label: "Project Name",
-            type: "text",
+            default: "classification",
+            label: "Model Type",
+            name: "model_type",
+            options: [
+              {
+                label: "Classification",
+                name: "classification",
+              },
+              {
+                label: "Regression",
+                name: "regression",
+              },
+            ],
             required: true,
+            type: "select",
+          },
+          {
+            default: "100",
+            description: "How many trials to run for training.",
+            label: "Trials to run",
+            name: "max_n_trials",
+            required: false,
+            type: "string",
+          },
+          {
+            default: "false",
+            label: "Train after data transfer",
+            name: "train_data",
+            options: [
+              {
+                label: "True",
+                name: "true",
+              },
+              {
+                label: "False",
+                name: "false",
+              },
+            ],
+            required: false,
+            type: "select",
           },
         ],
-      })
-
-      stubGet.restore()
+      }).and.notify(stubGet.restore)
     })
 
   })

--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -111,7 +111,7 @@ export class GoogleCloudStorageAction extends Hub.Action {
       label: "Overwrite",
       name: "overwrite",
       options: [{label: "Yes", name: "yes"}, {label: "No", name: "no"}],
-      default: "ignore",
+      default: "yes",
       description: "If Overwrite is enabled, will use the title or filename and overwrite existing data." +
         " If disabled, a date time will be appended to the name to make the file unique.",
     }]

--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -39,7 +39,12 @@ export class GoogleCloudStorageAction extends Hub.Action {
       throw "Need Google Cloud Storage bucket."
     }
 
-    const filename = request.formParams.filename || request.suggestedFilename()
+    let filename = request.formParams.filename || request.suggestedFilename()
+
+    // If the overwrite formParam exists and it is "no" - ensure a timestamp is appended
+    if (request.formParams.overwrite && request.formParams.overwrite === "no") {
+      filename += `_${Date.now()}`
+    }
 
     if (!filename) {
       throw new Error("Couldn't determine filename.")
@@ -102,6 +107,13 @@ export class GoogleCloudStorageAction extends Hub.Action {
       label: "Filename",
       name: "filename",
       type: "string",
+    }, {
+      label: "Overwrite",
+      name: "overwrite",
+      options: [{label: "Yes", name: "yes"}, {label: "No", name: "no"}],
+      default: "ignore",
+      description: "If Overwrite is enabled, will use the title or filename and overwrite existing data." +
+        " If disabled, a date time will be appended to the name to make the file unique.",
     }]
 
     return form

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -186,7 +186,7 @@ describe(`${action.constructor.name} unit tests`, () => {
           label: "Overwrite",
           name: "overwrite",
           options: [{label: "Yes", name: "yes"}, {label: "No", name: "no"}],
-          default: "ignore",
+          default: "yes",
           description: "If Overwrite is enabled, will use the title or filename and overwrite existing data." +
             " If disabled, a date time will be appended to the name to make the file unique.",
         }],

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -35,12 +35,14 @@ function expectGoogleCloudStorageMatch(request: Hub.ActionRequest,
 
   const stubSuggestedFilename = sinon.stub(request as any, "suggestedFilename")
     .callsFake(() => "stubSuggestedFilename")
-
+  const stubDate = sinon.stub(Date, "now")
+    .callsFake(() => "1234")
   return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
     chai.expect(bucketSpy).to.have.been.calledWithMatch(bucketMatch)
     chai.expect(fileSpy).to.have.been.calledWithMatch(fileMatch)
     stubClient.restore()
     stubSuggestedFilename.restore()
+    stubDate.restore()
   })
 }
 
@@ -99,7 +101,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         Buffer.from("1,2,3,4", "utf8"))
     })
 
-    it("sends to right filename if specified", () => {
+    it("sends to right filename if specified and overwrite yes", () => {
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Dashboard
       request.params = {
@@ -110,11 +112,33 @@ describe(`${action.constructor.name} unit tests`, () => {
       request.formParams = {
         bucket: "mybucket",
         filename: "mywackyfilename",
+        overwrite: "yes",
       }
       request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
       return expectGoogleCloudStorageMatch(request,
         "mybucket",
         "mywackyfilename",
+        Buffer.from("1,2,3,4", "utf8"))
+    })
+
+    it("sends to right filename if specified and overwrite no", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "mywackyfilename",
+        overwrite: "no",
+      }
+
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "mywackyfilename_1234",
         Buffer.from("1,2,3,4", "utf8"))
     })
 
@@ -158,6 +182,13 @@ describe(`${action.constructor.name} unit tests`, () => {
           label: "Filename",
           name: "filename",
           type: "string",
+        }, {
+          label: "Overwrite",
+          name: "overwrite",
+          options: [{label: "Yes", name: "yes"}, {label: "No", name: "no"}],
+          default: "ignore",
+          description: "If Overwrite is enabled, will use the title or filename and overwrite existing data." +
+            " If disabled, a date time will be appended to the name to make the file unique.",
         }],
       }).and.notify(stubClient.restore).and.notify(done)
     })


### PR DESCRIPTION
Add Overwrite form value to Google Cloud Storage. If there is a value and overwrite is set to "No" - the action will add a timestamp to the end of the filename
Fix Auger AI tests