### PR TITLE
🐛 [SEGMENT]: 0 dimension value bug fix

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -227,7 +227,7 @@ export class SegmentAction extends Hub.Action {
             winston.error("Field name does not exist for Segment action")
             throw new SegmentActionError(`Field id ${field.name} does not exist for JsonDetail.Row`)
           }
-          if (row[field.name].value) {
+          if (row[field.name].value || row[field.name].value === 0) {
             values[field.name] = row[field.name].value
           } else {
             values = this.filterJson(row[field.name], segmentFields, field.name)

--- a/src/actions/segment/test_segment_group.ts
+++ b/src/actions/segment/test_segment_group.ts
@@ -154,9 +154,9 @@ describe(`${action.constructor.name} unit tests`, () => {
       }
       request.attachment = {
         dataBuffer: Buffer.from(JSON.stringify({
-          fields: { dimensions: [{ name: "coolfield", tags: ["segment_group_id"] }, { name: 'zerofield' }] },
+          fields: { dimensions: [{ name: "coolfield", tags: ["segment_group_id"] }, { name: "zerofield" }] },
           data: [{ coolfield: { value: "funvalue" }, zerofield: { value: 0 } }],
-        }))
+        })),
       }
 
       return expectSegmentMatch(request, {

--- a/src/actions/segment/test_segment_group.ts
+++ b/src/actions/segment/test_segment_group.ts
@@ -146,6 +146,29 @@ describe(`${action.constructor.name} unit tests`, () => {
       })
     })
 
+    it("works with 0 dimension value", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Query
+      request.params = {
+        segment_write_key: "mykey",
+      }
+      request.attachment = {
+        dataBuffer: Buffer.from(JSON.stringify({
+          fields: { dimensions: [{ name: "coolfield", tags: ["segment_group_id"] }, { name: 'zerofield' }] },
+          data: [{ coolfield: { value: "funvalue" }, zerofield: { value: 0 } }],
+        }))
+      }
+
+      return expectSegmentMatch(request, {
+        groupId: "funvalue",
+        anonymousId: "stubanon",
+        userId: null,
+        traits: {
+          zerofield: 0,
+        },
+      })
+    })
+
   })
 
   describe("form", () => {


### PR DESCRIPTION
Currently, if a dimension has a value of 0 it is mapped to a segment trait as an empty array []. This simple fix allows us to successfully pass a value of 0 to segment. Included is a test to ensure there are no regressions on this functionality.