### PR TITLE
Slack Attachment bot user setup updates

### DIFF
--- a/src/actions/slack/legacy_slack/README.md
+++ b/src/actions/slack/legacy_slack/README.md
@@ -1,88 +1,60 @@
-# Slack Attachment
+# Slack Attachment (API Token)
 
-This action will post an attachment with your Looker data to a public Slack channel or direct message (DM).
+Perform this action to post an attachment with your Looker data to a public or private Slack channel or to a direct message (DM).
 
-You can configure which user (usually a bot user) the action will post the attachments by using the appropriate API token for that user.
+To use this action, you'll create an action app in the [api.slack.com](https://api.slack.com) interface that is tied to your Slack workspace and then configure a bot user from which the action will post the attachments by using the appropriate API token for that "user."
 
-## Getting Slack Credentials
+## Generating a Bot User Token in a Private Slack Action Application
 
-There are 2 ways of getting Slack credentials for use with this action.
-
-1. Bot user in a private Slack application (recommended)
-2. Slack legacy token
-
-### Bot user in a private Slack application
-
-1. Go to the Slack app creation page at https://api.slack.com/apps
+1. Go to the Slack API app page at [https://api.slack.com](https://api.slack.com/apps).
 
     ![](app-1.png)
 
-2. Click "Create New App" and enter an App Name and choose your company's Slack workspace for "Development Slack Workspace".
+2. Click **Create New App**. Enter a name for your app in the **App Name** field and select your company's Slack workspace from the **Development Slack Workspace** drop-down.
 
     ![](app-2.png)
 
+3. Once the app is created, click on the name of your app to open a page that allows you to further customize your app. Make sure your action app is selected in the drop-down in the upper left corner. 
 
-3. Once the app is created, go to the "Bot Users" tab in the sidebar and click "Add a Bot User".
+4. Click the **App Home** tab in the sidebar. Click **Review Scopes to Add** to configure the scopes for your action app's bot token. (According to the Slack documentation, a [bot user token](https://api.slack.com/authentication/token-types#bot) represents a bot associated with the app installed in a workspace. New bot users can request individual scopes, similar to user tokens. Unlike user tokens, bot user tokens are not tied to a user's identity; they're just tied to your app.)
 
-    ![](app-3.png)
+5. On the **Oauth & Permissions** tab, scroll down to the **Scopes** section. Under **Bot Token Scopes**, click **Add an OAuth Scope**. 
 
+![](slack_attachment_add_scope.png)
 
-4. Enter a name and username for your bot user. This is the user that Looker will send data as.
+From the drop-down of OAuth scopes, select:
+    
+    * `channels:read`
+    * `users:read`
+    * `files:write`
+    * `groups:read`
+    * `im:read`
+    * `mpim:read`
 
-    ![](app-4.png)
+![](slack_attachment_scopes.png)
 
+> For more information about exactly what these permissions allow the Looker action to do, visit the documentation for each of them:<br>
+    > - [https://api.slack.com/scopes/channels:read](https://api.slack.com/scopes/channels:read) <br>
+    > - [https://api.slack.com/scopes/users:read](https://api.slack.com/scopes/users:read) <br>
+    > - [https://api.slack.com/scopes/files:write](https://api.slack.com/scopes/files:write) <br>
+    > - [https://api.slack.com/scopes/groups:read](https://api.slack.com/scopes/groups:read) <br>
+    > - [https://api.slack.com/scopes/im:read](https://api.slack.com/scopes/im:read) <br>
+    > - [https://api.slack.com/scopes/mpim:read](https://api.slack.com/scopes/mpim:read) <br>
 
-5. On the sidebar, visit the "OAuth & Permissions" tab and scroll down to the "Scopes" section.
+6. At the top of the **OAuth & Permissions** page, click **Install App to Workspace**.
 
-    ![](app-5.png)
+![](slack_attachment_oauth_install.png)
 
-6. In the text box for "Add permission by scope or API method" add the following scopes:
+7. Click **Allow** to allow your Slack workspace to use your newly created app.
 
-    - `channels:read`
-    - `users:read`
-    - `files:write:user`
+![](slack_attachment_oauth_allow.png)
 
-    > For more information about exactly what these permissions allow the Looker action to do, visit the documentation for each of them:
-    > - https://api.slack.com/scopes/channels:read
-    > - https://api.slack.com/scopes/users:read
-    > - https://api.slack.com/scopes/files:write:user
+8. At the top of the **OAuth & Permissions** page, copy the **Bot User OAuth Access Token**.
 
-    When you're done it should look like this:
+![](slack_attachment_oauth_token.png)
 
-    ![](app-6.png)
+9. Enable the Slack Attachment (API Token) action in your Looker instance on the **Actions** page on the **Admin** panel. Paste in the token you copied.
 
-    Select "Save Changes".
+> Note: Remember to invite the bot user to any channels or groups that you might want to send data to!
 
-7. At the top of the "OAuth & Permissions" page click "Install App to Workspace".
-
-    ![](app-7.png)
-
-
-8. Click "Authorize" to allow your Slack workspace to use your newly created app.
-
-    ![](app-8.png)
-
-
-9. At the top of the "OAuth & Permissions" page copy the "Bot User OAuth Access Token".
-
-    ![](app-9.png)
-
-10. Enable Slack in Looker on the Actions page (/admin/actions) and use the token you copied.
-
-Note: Remember to invite the looker bot to any channels or groups that you might want to send data to!
-
-### Legacy Token
-
-Legacy tokens aren't reccomended since they expose more permissions than neccessary for the Looker action to work. However, you can use a legacy token as your API token for this action if you need to for some reason. The legacy token will post as yourself on Slack rather than a bot account.
-
-1. Go to your Slack [action token page](https://api.slack.com/custom-integrations/legacy-tokens).
-
-    ![](legacy-1.png)
-
-2. Select Create token
-
-    ![](legacy-2.png)
-
-3. Copy Token
-
-4. Enable Slack in Looker on the Actions page (/admin/actions) and use the token you copied.
+See the [Sending Data from Looker to Slack](https://help.looker.com/hc/en-us/articles/360023685774) article in the Looker Help Center for information about how to send or schedule data deliveries to the Slack Attachment (API Token) action.


### PR DESCRIPTION
Updated the Slack Attachment README with new bot user setup procedure and screenshots. Merge [this PR](https://github.com/looker/actions/pull/361) first.