### PR TITLE
Allow scheduled plan and attachment to be null in empty() check

### DIFF
--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -151,8 +151,8 @@ export class ActionRequest {
   lookerVersion: string | null = null
 
   empty(): boolean {
-    const url = !!this.scheduledPlan && !this.scheduledPlan.downloadUrl
-    const buffer = !!this.attachment && !this.attachment.dataBuffer
+    const url = !this.scheduledPlan || !this.scheduledPlan.downloadUrl
+    const buffer = !this.attachment || !this.attachment.dataBuffer
     return url && buffer
   }
 


### PR DESCRIPTION
We need to add the ability to send messages without payloads with no scheduled plan info.