### PR TITLE
Fix slack attachments on ios

### DIFF
--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -153,7 +153,7 @@ describe(`slack/utils unit tests`, () => {
             }
             return expectSlackMatch(request, {
                 file: request.attachment.dataBuffer,
-                filename: request.formParams.filename,
+                filename: `${request.formParams.filename}.csv`,
                 channels: request.formParams.channel,
                 initial_comment: request.formParams.initial_comment,
             })

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -93,7 +93,7 @@ export const handleExecute = async (request: Hub.ActionRequest, slack: WebClient
         throw "Missing channel."
     }
 
-    const fileName = request.formParams.filename || request.suggestedFilename()
+    const fileName = request.formParams.filename  ? request.completeFilename() : request.suggestedFilename()
 
     let response = new Hub.ActionResponse({success: true})
     try {

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -367,6 +367,15 @@ export class ActionRequest {
     return sanitizeFilename(`looker_file_${Date.now()}`)
   }
 
+  /** Returns filename with whitespace removed and the file extension included
+   */
+  completeFilename() {
+    if (this.attachment && this.formParams.filename) {
+      return `${this.formParams.filename.trim().replace(/\s/g, "_")}.${this.attachment.fileExtension}`
+    }
+    return this.formParams.filename
+  }
+
   /** creates a truncated message with a max number of lines and max number of characters with Title, Url,
    * and truncated Body of payload
    * @param {number} maxLines - maximum number of lines to truncate message

--- a/test/test.ts
+++ b/test/test.ts
@@ -12,6 +12,7 @@ winston.remove(winston.transports.Console)
 
 import "../src/actions/index"
 
+import "./test_action_request"
 import "./test_action_response"
 import "./test_actions"
 import "./test_json_detail_stream"

--- a/test/test_action_request.ts
+++ b/test/test_action_request.ts
@@ -70,4 +70,30 @@ describe("ActionRequest", () => {
       chai.expect(result.suggestedFilename()).to.equal(`Orders by County${expectedExtensions[i]}`)
     })
   })
+
+  it("ActionRequest.completeFilename removes whitespace and adds extension to filename", () => {
+    const formats = ["csv", "xlsx", "html", "txt", "pdf"]
+
+    formats.map((format) => {
+      const req = mockReq({
+        headers: {
+          "user-agent": "LookerOutgoingWebhook/7.3.0",
+          "x-looker-webhook-id": "123",
+          "x-looker-instance": "instanceId1",
+        },
+        body: {
+          form_params: {format, filename: " foo baz bar "},
+          scheduled_plan: {title: "Orders by County"},
+          attachment: {extension: format},
+        },
+      })
+
+      // @ts-ignore
+      req.header = (name: string): string | string[] | undefined => req.headers[name]
+
+      const result = ActionRequest.fromRequest(req)
+
+      chai.expect(result.completeFilename()).to.equal(`foo_baz_bar.${format}`)
+    })
+  })
 })


### PR DESCRIPTION
Remove whitespace and add file extensions to custom filenames for slack actions