### PR TITLE
Replace dot with underscore in property names for Hubspot action

### DIFF
--- a/src/actions/hubspot/hubspot.ts
+++ b/src/actions/hubspot/hubspot.ts
@@ -181,8 +181,8 @@ export class HubspotAction extends Hub.Action {
                 fieldName !== hubspotIdFieldName &&
                 hiddenFields.indexOf(fieldName) === -1
               ) {
-                const safeFieldName = fieldName.replace(".", "_");
-                properties[safeFieldName] = fieldSet.value;
+                const safeFieldName = fieldName.replace(".", "_")
+                properties[safeFieldName] = fieldSet.value
               }
             })
 

--- a/src/actions/hubspot/hubspot.ts
+++ b/src/actions/hubspot/hubspot.ts
@@ -181,7 +181,8 @@ export class HubspotAction extends Hub.Action {
                 fieldName !== hubspotIdFieldName &&
                 hiddenFields.indexOf(fieldName) === -1
               ) {
-                properties[fieldName] = fieldSet.value
+                const safeFieldName = fieldName.replace(".", "_");
+                properties[safeFieldName] = fieldSet.value;
               }
             })
 

--- a/src/actions/hubspot/hubspot.ts
+++ b/src/actions/hubspot/hubspot.ts
@@ -181,7 +181,7 @@ export class HubspotAction extends Hub.Action {
                 fieldName !== hubspotIdFieldName &&
                 hiddenFields.indexOf(fieldName) === -1
               ) {
-                const safeFieldName = fieldName.replace(".", "_")
+                const safeFieldName = fieldName.replace(/\./g, "_")
                 properties[safeFieldName] = fieldSet.value
               }
             })

--- a/src/actions/hubspot/test_hubspot_companies.ts
+++ b/src/actions/hubspot/test_hubspot_companies.ts
@@ -25,13 +25,13 @@ describe(`${action.constructor.name} unit tests`, () => {
           },
           data: [
             {
-              contact_id: { value: "0123456" },
-              property_one: { value: "property_one_value_1" },
+              "contact_id": { value: "0123456" },
+              "property_one": { value: "property_one_value_1" },
               "property.two": { value: "property_two_value_1" },
             },
             {
-              contact_id: { value: "9876543" },
-              property_one: { value: "property_one_value_2" },
+              "contact_id": { value: "9876543" },
+              "property_one": { value: "property_one_value_2" },
               "property.two": { value: "property_two_value_2" },
             },
           ],
@@ -42,16 +42,16 @@ describe(`${action.constructor.name} unit tests`, () => {
       inputs: [
         {
           id: "0123456",
-          properties: { 
-            property_one: "property_one_value_1", 
-            "property_two": "property_two_value_1" 
+          properties: {
+            property_one: "property_one_value_1",
+            property_two: "property_two_value_1",
           },
         },
         {
           id: "9876543",
-          properties: { 
-            property_one: "property_one_value_2", 
-            "property_two": "property_two_value_2" 
+          properties: {
+            property_one: "property_one_value_2",
+            property_two: "property_two_value_2",
           },
         },
       ],

--- a/src/actions/hubspot/test_hubspot_companies.ts
+++ b/src/actions/hubspot/test_hubspot_companies.ts
@@ -20,16 +20,19 @@ describe(`${action.constructor.name} unit tests`, () => {
             dimensions: [
               { name: "contact_id", tags: ["hubspot_company_id"] },
               { name: "property_one" },
+              { name: "property.two" },
             ],
           },
           data: [
             {
               contact_id: { value: "0123456" },
               property_one: { value: "property_one_value_1" },
+              "property.two": { value: "property_two_value_1" },
             },
             {
               contact_id: { value: "9876543" },
               property_one: { value: "property_one_value_2" },
+              "property.two": { value: "property_two_value_2" },
             },
           ],
         }),
@@ -39,11 +42,17 @@ describe(`${action.constructor.name} unit tests`, () => {
       inputs: [
         {
           id: "0123456",
-          properties: { property_one: "property_one_value_1" },
+          properties: { 
+            property_one: "property_one_value_1", 
+            "property_two": "property_two_value_1" 
+          },
         },
         {
           id: "9876543",
-          properties: { property_one: "property_one_value_2" },
+          properties: { 
+            property_one: "property_one_value_2", 
+            "property_two": "property_two_value_2" 
+          },
         },
       ],
     })

--- a/src/actions/hubspot/test_hubspot_contacts.ts
+++ b/src/actions/hubspot/test_hubspot_contacts.ts
@@ -25,13 +25,13 @@ describe(`${action.constructor.name} unit tests`, () => {
           },
           data: [
             {
-              contact_id: { value: "0123456" },
-              property_one: { value: "property_one_value_1" },
+              "contact_id": { value: "0123456" },
+              "property_one": { value: "property_one_value_1" },
               "property.two": { value: "property_two_value_1" },
             },
             {
-              contact_id: { value: "9876543" },
-              property_one: { value: "property_one_value_2" },
+              "contact_id": { value: "9876543" },
+              "property_one": { value: "property_one_value_2" },
               "property.two": { value: "property_two_value_2" },
             },
           ],
@@ -42,16 +42,16 @@ describe(`${action.constructor.name} unit tests`, () => {
       inputs: [
         {
           id: "0123456",
-          properties: { 
-            property_one: "property_one_value_1", 
-            "property_two": "property_two_value_1" 
+          properties: {
+            property_one: "property_one_value_1",
+            property_two: "property_two_value_1",
           },
         },
         {
           id: "9876543",
-          properties: { 
-            property_one: "property_one_value_2", 
-            "property_two": "property_two_value_2" 
+          properties: {
+            property_one: "property_one_value_2",
+            property_two: "property_two_value_2",
           },
         },
       ],

--- a/src/actions/hubspot/test_hubspot_contacts.ts
+++ b/src/actions/hubspot/test_hubspot_contacts.ts
@@ -20,16 +20,19 @@ describe(`${action.constructor.name} unit tests`, () => {
             dimensions: [
               { name: "contact_id", tags: ["hubspot_contact_id"] },
               { name: "property_one" },
+              { name: "property.two" },
             ],
           },
           data: [
             {
               contact_id: { value: "0123456" },
               property_one: { value: "property_one_value_1" },
+              "property.two": { value: "property_two_value_1" },
             },
             {
               contact_id: { value: "9876543" },
               property_one: { value: "property_one_value_2" },
+              "property.two": { value: "property_two_value_2" },
             },
           ],
         }),
@@ -39,11 +42,17 @@ describe(`${action.constructor.name} unit tests`, () => {
       inputs: [
         {
           id: "0123456",
-          properties: { property_one: "property_one_value_1" },
+          properties: { 
+            property_one: "property_one_value_1", 
+            "property_two": "property_two_value_1" 
+          },
         },
         {
           id: "9876543",
-          properties: { property_one: "property_one_value_2" },
+          properties: { 
+            property_one: "property_one_value_2", 
+            "property_two": "property_two_value_2" 
+          },
         },
       ],
     })


### PR DESCRIPTION
We've been trying to use the Hubspot action to send some data from looker into Hubspot company properties. This is not working due to the fact that looker sends data in the form of `view.dimension`, for example: `customer.revenue` to Hubspot properties. However Hubspot properties do not support the use of dots `.` in their names.

This PR replaces those dots with underscores, which is the default behaviour when adding a dot in a property name in the Hubspot UI.

Tagging @luskin since you were the original author, thanks for creating this custom action!