### PR TITLE
Remove vscode settings and tweak gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,10 +56,12 @@ typings/
 
 # dotenv environment variables file
 .env
-status.json
-lib
 
-# For IdeaStorm
+# Common editors etc
 .idea/
-
+.vscode/
 .DS_Store
+
+# ActionHub specifics
+status.json
+/lib/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "files.exclude": {
-    "lib": true
-  }
-}


### PR DESCRIPTION
Here's the story:

I added a `lib` folder to my action directory, but realized it wasn't being tracked by git. This is because the .gitignore had an entry for "lib".

But I couldn't see a root "lib" folder in my VS Code editor... Eventually I realized that the `.vscode/settings.json` file present in the repo was ignoring it. This file was originally added by Wil several years ago.

It makes sense that some people would want to change their editor settings, but those should be customized on a per-user basis, not made part of the repo itself.

So this commit deletes the `.vscode` folder and adds it to the gitignore for the future.

I've also modified the "lib" line to "/lib/" so it will only match on the root folder and not any subfolders or files.

I also slightly rearranged the entries and updated the comments... feel free to suggest revisions that you think make more sense.

Thanks!