### PR TITLE
GCS action: handle new scenario where getBuckets returns '[[]]'

### DIFF
--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -87,7 +87,7 @@ export class GoogleCloudStorageAction extends Hub.Action {
       return form
     }
 
-    if (!(results && results[0])) {
+    if (!(results && results[0] && results[0][0])) {
       form.error = "No buckets in account."
       return form
     }

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -197,7 +197,7 @@ describe(`${action.constructor.name} unit tests`, () => {
 
       const stubClient = sinon.stub(action as any, "gcsClientFromRequest")
         .callsFake(() => ({
-          getBuckets: async () => Promise.resolve(),
+          getBuckets: async () => Promise.resolve([[]]),
         }))
 
       const request = new Hub.ActionRequest()


### PR DESCRIPTION
Customer encountered issue setting up the GCS action when they had no buckets in the project: https://chat.google.com/room/AAAAcWxwtps/JR8v5hE2wEQ

There was already a test case for the scenario of missing buckets, but it seems maybe the API response has changed since then. Now we appear to get `[[]]`, so this PR just adds one level deeper existence check.