### PR TITLE
Fetch only users or forms for slack form requests

### DIFF
--- a/src/actions/google/ads/lib/ads_request.ts
+++ b/src/actions/google/ads/lib/ads_request.ts
@@ -128,7 +128,7 @@ export class GoogleAdsActionRequest {
       if (!newListName) {
         throw new MissingRequiredParamsError("Name for new list is missing")
       }
-      const timestamp = new Date().toISOString().substr(0, 19).replace('T', ' ')
+      const timestamp = new Date().toISOString().substr(0, 19).replace("T", " ")
       const newListNameWithTimestamp = `${newListName} (from Looker ${timestamp}Z)`
       await executor.createUserList(newListNameWithTimestamp, newListDescription)
     } else {

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -29,7 +29,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
     let channelType = "channels"
-    if (request.formParams.channelType !== undefined && request.formParams.channelType !== "users") {
+    if (request.formParams.channelType !== undefined && request.formParams.channelType === "users") {
       channelType = "users"
     }
 

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -1,6 +1,7 @@
 import * as Hub from "../../../hub"
 
 import { WebClient } from "@slack/client"
+import _ = require("lodash")
 import {displayError, getDisplayedFormFields, handleExecute} from "../utils"
 
 export class SlackAttachmentAction extends Hub.Action {
@@ -28,10 +29,8 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
-    let channelType = "channels"
-    if (request.formParams.channelType !== undefined && request.formParams.channelType === "users") {
-      channelType = "users"
-    }
+    const channelType = _.isNil(request.formParams.channelType) && request.formParams.channelType === "users"
+        ? "users" : "channels"
 
     try {
       form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request), channelType)

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -28,9 +28,13 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
+    let channelType = "channels"
+    if (request.formParams.channelType !== undefined && request.formParams.channelType !== "users") {
+      channelType = "users"
+    }
 
     try {
-      form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request))
+      form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request), channelType)
     } catch (e) {
       form.error = displayError[e.message] || e
     }

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -29,8 +29,8 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
-    const channelType = _.isNil(request.formParams.channelType) && request.formParams.channelType === "users"
-        ? "users" : "channels"
+    const channelType = _.isNil(request.formParams.channelType) || request.formParams.channelType === "channels"
+        ? "channels" : "users"
 
     try {
       form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request), channelType)

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -81,8 +81,13 @@ export class SlackAction extends Hub.DelegateOAuthAction {
       return this.loginForm(request, form)
     }
 
+    let channelType = "channels"
+    if (request.formParams.channelType !== undefined && request.formParams.channelType !== "users") {
+      channelType = "users"
+    }
+
     try {
-      form.fields = form.fields.concat(await getDisplayedFormFields(client))
+      form.fields = form.fields.concat(await getDisplayedFormFields(client, channelType))
     } catch (e) {
       return this.loginForm(request, form)
     }

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -82,7 +82,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
     }
 
     let channelType = "channels"
-    if (request.formParams.channelType !== undefined && request.formParams.channelType !== "users") {
+    if (request.formParams.channelType !== undefined && request.formParams.channelType === "users") {
       channelType = "users"
     }
 

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -1,4 +1,5 @@
 import {WebClient} from "@slack/client"
+import _ = require("lodash")
 import * as winston from "winston"
 import * as Hub from "../../hub"
 import {isSupportMultiWorkspaces, SlackClientManager} from "./slack_client_manager"
@@ -81,10 +82,8 @@ export class SlackAction extends Hub.DelegateOAuthAction {
       return this.loginForm(request, form)
     }
 
-    let channelType = "channels"
-    if (request.formParams.channelType !== undefined && request.formParams.channelType === "users") {
-      channelType = "users"
-    }
+    const channelType = _.isNil(request.formParams.channelType) && request.formParams.channelType === "users"
+        ? "users" : "channels"
 
     try {
       form.fields = form.fields.concat(await getDisplayedFormFields(client, channelType))

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -82,8 +82,8 @@ export class SlackAction extends Hub.DelegateOAuthAction {
       return this.loginForm(request, form)
     }
 
-    const channelType = _.isNil(request.formParams.channelType) && request.formParams.channelType === "users"
-        ? "users" : "channels"
+    const channelType = _.isNil(request.formParams.channelType) || request.formParams.channelType === "channels"
+        ? "channels" : "users"
 
     try {
       form.fields = form.fields.concat(await getDisplayedFormFields(client, channelType))

--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -93,8 +93,16 @@ describe(`slack/utils unit tests`, () => {
                         next_cursor: "cursor",
                     },
                 })
-            const result = getDisplayedFormFields(slackClient)
+            const result = getDisplayedFormFields(slackClient, "channels")
             chai.expect(result).to.eventually.deep.equal([
+                {
+                    description: "Type of destination to fetch",
+                    label: "Channel Type",
+                    name: "channelType",
+                    options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
+                    type: "select",
+                    default: "channels",
+                },
                 {
                     description: "Name of the Slack channel you would like to post to.",
                     label: "Share In",
@@ -104,6 +112,77 @@ describe(`slack/utils unit tests`, () => {
                         {name: "2", label: "#B"},
                         {name: "3", label: "#C"},
                         {name: "4", label: "#D"},
+                    ],
+                    required: true,
+                    type: "select",
+                }, {
+                    label: "Comment",
+                    type: "string",
+                    name: "initial_comment",
+                }, {
+                    label: "Filename",
+                    name: "filename",
+                    type: "string",
+                },
+            ]).and.notify(done)
+        })
+
+        it("returns correct users", (done) => {
+            const slackClient = new WebClient("token")
+            // @ts-ignore
+            sinon.stub(slackClient.conversations, "list").callsFake((filters: any) => filters.cursor ?
+                {
+                    ok: true,
+                    channels: [
+                        {id: "3", name: "C", is_member: true},
+                        {id: "4", name: "D", is_member: true},
+                    ],
+                } :
+                {
+                    ok: true,
+                    channels: [
+                        {id: "1", name: "A", is_member: true},
+                        {id: "2", name: "B", is_member: true},
+                    ],
+                    response_metadata: {
+                        next_cursor: "cursor",
+                    },
+                },
+            )
+            // @ts-ignore
+            sinon.stub(slackClient.users, "list").callsFake((filters: any) => filters.cursor ?
+                {
+                    ok: true,
+                    members: [
+                        {id: "30", name: "W"},
+                        {id: "40", name: "X"},
+                    ],
+                } :
+                {
+                    ok: true,
+                    members: [
+                        {id: "10", name: "Z"},
+                        {id: "20", name: "Y"},
+                    ],
+                    response_metadata: {
+                        next_cursor: "cursor",
+                    },
+                })
+            const result = getDisplayedFormFields(slackClient, "users")
+            chai.expect(result).to.eventually.deep.equal([
+                {
+                    description: "Type of destination to fetch",
+                    label: "Channel Type",
+                    name: "channelType",
+                    options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
+                    type: "select",
+                    default: "channels",
+                },
+                {
+                    description: "Name of the Slack channel you would like to post to.",
+                    label: "Share In",
+                    name: "channel",
+                    options: [
                         {name: "30", label: "@W"},
                         {name: "40", label: "@X"},
                         {name: "20", label: "@Y"},

--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -102,6 +102,7 @@ describe(`slack/utils unit tests`, () => {
                     options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
                     type: "select",
                     default: "channels",
+                    interactive: true,
                 },
                 {
                     description: "Name of the Slack channel you would like to post to.",
@@ -177,6 +178,7 @@ describe(`slack/utils unit tests`, () => {
                     options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
                     type: "select",
                     default: "channels",
+                    interactive: true,
                 },
                 {
                     description: "Name of the Slack channel you would like to post to.",

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -75,6 +75,7 @@ export const getDisplayedFormFields = async (slack: WebClient, channelType: stri
             options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
             type: "select",
             default: "channels",
+            interactive: true,
         },
         {
             description: "Name of the Slack channel you would like to post to.",

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -59,16 +59,23 @@ const usableDMs = async (slack: WebClient): Promise<Channel[]> => {
     return users.map((user: any) => ({id: user.id, label: `@${user.name}`}))
 }
 
-const usableChannels = async (slack: WebClient): Promise<Channel[]> => {
-    let channels = await _usableChannels(slack)
-    channels = channels.concat(await usableDMs(slack))
+export const getDisplayedFormFields = async (slack: WebClient, channelType: string): Promise<ActionFormField[]> => {
+    let channels
+    if (channelType === "channels") {
+        channels = await _usableChannels(slack)
+    } else {
+        channels = await usableDMs(slack)
+    }
     channels.sort((a, b) => ((a.label < b.label) ? -1 : 1 ))
-    return channels
-}
-
-export const getDisplayedFormFields = async (slack: WebClient): Promise<ActionFormField[]> => {
-    const channels = await usableChannels(slack)
     return [
+        {
+            description: "Type of destination to fetch",
+            label: "Channel Type",
+            name: "channelType",
+            options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
+            type: "select",
+            default: "channels",
+        },
         {
             description: "Name of the Slack channel you would like to post to.",
             label: "Share In",


### PR DESCRIPTION
This will change the behavior of the Slack form to by default only fetch Channels first, with an option to select users instead. The goal of this change is to reduce the amount of entries initially loaded into the form and stay within Slack API rate limits