### PR TITLE
Ensure that filetype is preserved for GCS uploads with overwrite false

### DIFF
--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -2,6 +2,8 @@ import * as Hub from "../../../hub"
 
 const storage = require("@google-cloud/storage")
 
+const FILE_EXTENSION = new RegExp(/(.*[^.])\.(.*)/)
+
 export class GoogleCloudStorageAction extends Hub.Action {
 
   name = "google_cloud_storage"
@@ -43,7 +45,12 @@ export class GoogleCloudStorageAction extends Hub.Action {
 
     // If the overwrite formParam exists and it is "no" - ensure a timestamp is appended
     if (request.formParams.overwrite && request.formParams.overwrite === "no") {
-      filename += `_${Date.now()}`
+      const captures = filename.match(FILE_EXTENSION)
+      if (captures && captures.length > 1) {
+        filename = captures[1] + `_${Date.now()}.` + captures[2]
+      } else {
+        filename += `_${Date.now()}`
+      }
     }
 
     if (!filename) {

--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -2,7 +2,7 @@ import * as Hub from "../../../hub"
 
 const storage = require("@google-cloud/storage")
 
-const FILE_EXTENSION = new RegExp(/(.*[^.])\.(.*)/)
+const FILE_EXTENSION = new RegExp(/(.*)\.(.*)$/)
 
 export class GoogleCloudStorageAction extends Hub.Action {
 

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -142,6 +142,28 @@ describe(`${action.constructor.name} unit tests`, () => {
         Buffer.from("1,2,3,4", "utf8"))
     })
 
+    it("sends to right filename if specified and overwrite no with attachment", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "mywackyfilename.csv",
+        overwrite: "no",
+      }
+
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+          "mybucket",
+          "mywackyfilename_1234.csv",
+          Buffer.from("1,2,3,4", "utf8"))
+    })
+
+
   })
 
   describe("form", () => {

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -142,7 +142,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         Buffer.from("1,2,3,4", "utf8"))
     })
 
-    it("sends to right filename if specified and overwrite no with attachment", () => {
+    it("sends to right filename if specified and overwrite no with attachment extension", () => {
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Dashboard
       request.params = {
@@ -162,8 +162,26 @@ describe(`${action.constructor.name} unit tests`, () => {
           "mywackyfilename_1234.csv",
           Buffer.from("1,2,3,4", "utf8"))
     })
+    it("sends to right filename if specified and overwrite no with attachment with multiple .", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "mywackyfilename.carl.csv",
+        overwrite: "no",
+      }
 
-
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+          "mybucket",
+          "mywackyfilename.carl_1234.csv",
+          Buffer.from("1,2,3,4", "utf8"))
+    })
   })
 
   describe("form", () => {


### PR DESCRIPTION
Reorder the filename logic to ensure the extension is always at the end for overwrite = "no"