### PR TITLE
Google Ads Customer Match - Mobile Device IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,6 @@ PORT=8080
 # Can be generated with something like `openssl rand -hex 32`
 CIPHER_MASTER=281243e09385f19773569e4d99d306065efb0cf0f6e3ca4c705571c173722c99
 # Use this in development to turn on debug logging
-ACTION_DEBUG=1
+ACTION_HUB_DEBUG=1
 # Use this in development to filter the list of actions exposed to Looker
 ACTION_WHITELIST=my_new_action_name,other_action_name

--- a/src/actions/google/ads/lib/ads_executor.ts
+++ b/src/actions/google/ads/lib/ads_executor.ts
@@ -6,6 +6,8 @@ export class GoogleAdsActionExecutor {
   readonly apiClient = this.adsRequest.apiClient!
   readonly log = this.adsRequest.log
   readonly targetCid = this.adsRequest.targetCid
+  readonly mobileAppId = this.adsRequest.mobileAppId
+  readonly uploadKeyType = this.adsRequest.uploadKeyType
   offlineUserDataJobResourceName: string
   targetUserListRN: string
 
@@ -15,7 +17,8 @@ export class GoogleAdsActionExecutor {
   }
 
   async createUserList(newListName: string, newListDescription: string) {
-    const createListResp = await this.apiClient.createUserList(this.targetCid, newListName, newListDescription)
+    const createListResp = await this.apiClient.createUserList(this.targetCid, newListName, newListDescription,
+      this.mobileAppId, this.uploadKeyType)
     this.targetUserListRN = createListResp.results[0].resourceName
     this.log("info", "Created user list: ", this.targetUserListRN)
     return

--- a/src/actions/google/ads/lib/ads_request.ts
+++ b/src/actions/google/ads/lib/ads_request.ts
@@ -73,6 +73,22 @@ export class GoogleAdsActionRequest {
     return this.formParams.createOrAppend
   }
 
+  get mobileDevice() {
+    return this.formParams.mobileDevice
+  }
+
+  get isMobileDevice() {
+    return this.mobileDevice === "yes"
+  }
+
+  get mobileAppId() {
+    return this.formParams.mobileAppId
+  }
+
+  get uploadKeyType() {
+    return this.isMobileDevice ? "MOBILE_ADVERTISING_ID" : "CONTACT_INFO"
+  }
+
   get developerToken() {
     return this.actionInstance.developerToken
   }
@@ -111,6 +127,9 @@ export class GoogleAdsActionRequest {
       throw new MissingRequiredParamsError(
         `createOrAppend must be either 'create' or 'append' (got '${this.formParams.createOrAppend}')`,
       )
+    }
+    if (this.isMobileDevice && !this.mobileAppId) {
+      throw new MissingRequiredParamsError("Mobile application id is missing")
     }
     if (!["yes", "no"].includes(this.formParams.doHashing)) {
       throw new MissingRequiredParamsError(`Hashing must be either 'yes' or 'no' (got '${this.formParams.doHashing}')`)

--- a/src/actions/google/ads/lib/api_client.ts
+++ b/src/actions/google/ads/lib/api_client.ts
@@ -16,7 +16,7 @@ export class GoogleAdsApiClient {
       return this.apiCall(method, path)
     }
 
-    async searchOpenUserLists(clientCid: string) {
+    async searchOpenUserLists(clientCid: string, uploadKeyType: "MOBILE_ADVERTISING_ID" | "CONTACT_INFO") {
       const method = "POST"
       const path = `customers/${clientCid}/googleAds:searchStream`
       const body = {
@@ -26,7 +26,8 @@ export class GoogleAdsApiClient {
           + " WHERE user_list.type = 'CRM_BASED'"
           + " AND user_list.read_only = FALSE"
           + " AND user_list.account_user_list_status = 'ENABLED'"
-          + " AND user_list.membership_status = 'OPEN'",
+          + " AND user_list.membership_status = 'OPEN'"
+          + ` AND user_list.crm_based_user_list.upload_key_type = '${uploadKeyType}'`,
       }
       return this.apiCall(method, path, body)
     }
@@ -50,7 +51,8 @@ export class GoogleAdsApiClient {
       return this.apiCall(method, path, body)
     }
 
-    async createUserList(targetCid: string, newListName: string, newListDescription: string) {
+    async createUserList(targetCid: string, newListName: string, newListDescription: string, mobileAppId: string,
+                         uploadKeyType: "MOBILE_ADVERTISING_ID" | "CONTACT_INFO") {
       const method = "POST"
       const path = `customers/${targetCid}/userLists:mutate`
       const body = {
@@ -63,7 +65,8 @@ export class GoogleAdsApiClient {
               membership_status: "OPEN",
               membership_life_span: 10000,
               crm_based_user_list: {
-                upload_key_type: "CONTACT_INFO",
+                upload_key_type: uploadKeyType,
+                app_id: mobileAppId,
                 data_source_type: "FIRST_PARTY",
               },
             },

--- a/src/actions/google/ads/lib/data_uploader.ts
+++ b/src/actions/google/ads/lib/data_uploader.ts
@@ -28,16 +28,25 @@ export class GoogleAdsUserListUploader {
    * Schema object: {"User Email Address": "hashed_email", "US Zipcode": "address_info.postal_code"}
    * Parsed result: [{"hashed_email": "lukeperry@example.com"}, {"address_info": {"postal_code": "90210"}}]
    *                                   ^^^^^^^ Except the email could actually be a hash
+   *
+   * Note: mobile device data cannot be combined with any other types of customer data,
+   * therefore the regex conditions are kept separate
    */
   private regexes = [
-    [/email/i, "hashed_email"],
-    [/phone/i, "hashed_phone_number"],
-    [/first/i, "address_info.hashed_first_name"],
-    [/last/i, "address_info.hashed_last_name"],
-    [/city/i, "address_info.city"],
-    [/state/i, "address_info.state"],
-    [/country/i, "address_info.country_code"],
-    [/postal|zip/i, "address_info.postal_code"],
+    ... this.adsRequest.isMobileDevice ? [
+      [/idfa|identifier.for.advertising/i, "mobile_id"],
+      [/aaid|advertiser.assigned.user|google.advertising/i, "third_party_user_id"],
+    ] : [
+      [/email/i, "hashed_email"],
+      [/phone/i, "hashed_phone_number"],
+      [/first/i, "address_info.hashed_first_name"],
+      [/last/i, "address_info.hashed_last_name"],
+      [/street|address/i, "address_info.hashed_street_address"],
+      [/city/i, "address_info.city"],
+      [/state/i, "address_info.state"],
+      [/country/i, "address_info.country_code"],
+      [/postal|zip/i, "address_info.postal_code"],
+    ],
   ]
 
   constructor(readonly adsExecutor: GoogleAdsActionExecutor) {}


### PR DESCRIPTION
This PR is to add functionality for Customer Match to work with [mobile device IDs](https://developers.google.com/google-ads/api/docs/remarketing/audience-types/customer-match#customer_match_with_mobile_device_ids)

Mobile device data cannot be combined with any other types of customer data, so a new faceted form "branch" is created and the regex conditions for column labels are kept separate.

Also a tiny update to the `.env.example` to use the correct debug logging parameter