### PR TITLE
add `chat:write` scope to oauth scope reqs

### DIFF
--- a/src/actions/slack/legacy_slack/README.md
+++ b/src/actions/slack/legacy_slack/README.md
@@ -30,6 +30,7 @@ From the drop-down of OAuth scopes, select:
     * `groups:read`
     * `im:read`
     * `mpim:read`
+    * `chat:write`
 
 ![](slack_attachment_scopes.png)
 
@@ -40,6 +41,7 @@ From the drop-down of OAuth scopes, select:
     > - [https://api.slack.com/scopes/groups:read](https://api.slack.com/scopes/groups:read) <br>
     > - [https://api.slack.com/scopes/im:read](https://api.slack.com/scopes/im:read) <br>
     > - [https://api.slack.com/scopes/mpim:read](https://api.slack.com/scopes/mpim:read) <br>
+    > - [https://api.slack.com/scopes/chat:write](chat:write) <br>
 
 6. At the top of the **OAuth & Permissions** page, click **Install App to Workspace**.
 


### PR DESCRIPTION
Added [chat:write](https://api.slack.com/scopes/chat:write) scope.