### PR TITLE
segment allow use of field name as specified in Looker via field.label_short

### DIFF
--- a/src/actions/segment/segment.ts
+++ b/src/actions/segment/segment.ts
@@ -222,6 +222,13 @@ export class SegmentAction extends Hub.Action {
   ) {
     const traits: { [key: string]: string } = {}
     for (const field of fields) {
+      /**
+       * Using the short label here allows us to specify the exact field we'd like
+       * to send to Segment. Otherwise, the "name" field is determined by Looker for
+       * us, and has its own limitations (e.g. it does not support uppercase characters).
+       */
+      const traitName = field.label_short || field.name
+      
       if (segmentFields.idFieldNames.indexOf(field.name) === -1) {
         if (hiddenFields.indexOf(field.name) === -1) {
           let values: any = {}

--- a/src/actions/segment/test_segment.ts
+++ b/src/actions/segment/test_segment.ts
@@ -161,6 +161,31 @@ describe(`${action.constructor.name} unit tests`, () => {
       })
     })
 
+    it("uses the field's short label as the trait name when present", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Query
+      request.params = {
+        segment_write_key: "mykey",
+      }
+      request.attachment = {dataBuffer: Buffer.from(JSON.stringify({
+        fields: {dimensions: [
+          {name: "coolid", tags: ["user_id"]},
+          {name: "cooltrait", label_short: "coolshortlabel", tags: []},
+        ]},
+        data: [{
+          coolid: {value: "id"},
+          cooltrait: {value: "funtrait"},
+        }],
+      }))}
+      return expectSegmentMatch(request, {
+        userId: "id",
+        traits: {
+          coolshortlabel: "funtrait",
+        },
+        anonymousId: null,
+      })
+    })
+    
     it("works with user id and anonymous id", () => {
       const request = new Hub.ActionRequest()
       request.type = Hub.ActionType.Query


### PR DESCRIPTION
Using the short label here allows us to specify the exact field we'd like to send to Segment. Otherwise, the "name" field is determined by Looker for us, and has its own limitations (e.g. it does not support uppercase characters).
Related Issue - https://github.com/looker/actions/issues/130