### PR TITLE
Patches for Google Ads Cstomer Match

### DIFF
--- a/src/actions/google/ads/lib/ads_executor.ts
+++ b/src/actions/google/ads/lib/ads_executor.ts
@@ -18,7 +18,7 @@ export class GoogleAdsActionExecutor {
 
   async createUserList(newListName: string, newListDescription: string) {
     const createListResp = await this.apiClient.createUserList(this.targetCid, newListName, newListDescription,
-      this.mobileAppId, this.uploadKeyType)
+      this.uploadKeyType, this.mobileAppId)
     this.targetUserListRN = createListResp.results[0].resourceName
     this.log("info", "Created user list: ", this.targetUserListRN)
     return

--- a/src/actions/google/ads/lib/ads_request.ts
+++ b/src/actions/google/ads/lib/ads_request.ts
@@ -46,7 +46,8 @@ export class GoogleAdsActionRequest {
   }
 
   async checkTokens() {
-    if ( this.userState.tokens.expiry_date == null || this.userState.tokens.expiry_date < Date.now() ) {
+    // adding 5 minutes to expiry_date check to handle refresh edge case
+    if ( this.userState.tokens.expiry_date == null || this.userState.tokens.expiry_date < (Date.now() + 5 * 60000) ) {
       this.log("debug", "Tokens appear expired; attempting refresh.")
 
       const data = await this.actionInstance.oauthHelper.refreshAccessToken(this.userState.tokens)
@@ -62,7 +63,7 @@ export class GoogleAdsActionRequest {
   }
 
   setApiClient() {
-    this.apiClient = new GoogleAdsApiClient(this.accessToken, this.developerToken, this.loginCid)
+    this.apiClient = new GoogleAdsApiClient(this.log, this.accessToken, this.developerToken, this.loginCid)
   }
 
   get accessToken() {

--- a/src/actions/google/ads/test_customer_match.ts
+++ b/src/actions/google/ads/test_customer_match.ts
@@ -147,7 +147,7 @@ describe(`${action.constructor.name} class`, () => {
           "https://accounts.google.com/o/oauth2/v2/auth" +
           "?access_type=offline" +
           "&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords" +
-          "&prompt=consent" +
+          "&prompt=select_account" +
           "&state=not-actually-encrypted-payload-used-for-test" +
           "&response_type=code" +
           "&client_id=test_oauth_client_id" +

--- a/src/actions/google/analytics/test_data_import.ts
+++ b/src/actions/google/analytics/test_data_import.ts
@@ -680,7 +680,7 @@ describe(`${action.constructor.name} class`, () => {
           "https://accounts.google.com/o/oauth2/v2/auth" +
           "?access_type=offline" +
           "&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fanalytics.edit" +
-          "&prompt=consent" +
+          "&prompt=select_account" +
           "&state=not-actually-encrypted-payload-used-for-test" +
           "&response_type=code" +
           "&client_id=test_oauth_client_id" +

--- a/src/actions/google/common/error_utils.ts
+++ b/src/actions/google/common/error_utils.ts
@@ -13,6 +13,11 @@ export function sanitizeError(err: any) {
     }
   }
 
+  // Remove tokens from data
+  if (err.config && err.config.data && err.config.data.tokens) {
+    err.config.data.tokens = "[REDACTED]"
+  }
+
   // Remove data payload - this is hashed but makes the logs unreadable
   if (err.config && err.config.data && err.config.data.operations) {
     err.config.data.operations = "[TRUNCATED]"

--- a/src/actions/google/common/oauth_helper.ts
+++ b/src/actions/google/common/oauth_helper.ts
@@ -2,6 +2,7 @@ import * as gaxios from "gaxios"
 import * as googleAuth from "google-auth-library"
 import { google } from "googleapis"
 import * as Hub from "../../../hub"
+import { sanitizeError } from "./error_utils"
 import { Logger } from "./logger"
 
 // Double dispatch type pattern at work here
@@ -81,7 +82,7 @@ export class GoogleOAuthHelper {
       const url = oauthClient.generateAuthUrl({
         access_type: "offline",
         scope: this.actionInstance.oauthScopes,
-        prompt: "consent",
+        prompt: "select_account",
         state: encryptedPayload,
       })
 
@@ -128,6 +129,7 @@ export class GoogleOAuthHelper {
           this.log("debug", "Ignoring state update response with response code <100")
         } else {
           this.log("error", "Error sending user state to Looker:", err.toString())
+          sanitizeError(err)
           throw err
         }
       }


### PR DESCRIPTION
- updated refreshToken logic to catch edge cases
- fixed form login loop for authorization errors from API client
- updated UserData object for addOperations as per: https://ads-developers.googleblog.com/2021/10/userdata-enforcement-in-google-ads-api.html
- updated consent screen to prompt select_account
- upgraded to google ads API to v9